### PR TITLE
custom pageのメタ情報を上書きする

### DIFF
--- a/articles.hbs
+++ b/articles.hbs
@@ -1,30 +1,35 @@
 {{!< default}}
 <section class="gh-all-articles-tags-section">
- {{#get "tags" limit="all"}}
-    <div class="gh-all-article-tags">
-    {{#foreach tags}}
-        <a class="gh-all-article-tag" href="{{url}}">{{name}}</a>
-    {{/foreach}}
-    </div>
-{{/get}}
+	{{#get "tags" limit="all"}}
+		<div class="gh-all-article-tags">
+			{{#foreach tags}}
+				<a class="gh-all-article-tag" href="{{url}}">{{name}}</a>
+			{{/foreach}}
+		</div>
+	{{/get}}
 </section>
 <section class="gh-all-articles">
-    <h2>Articles</h2>
-
-    <div id="post-feed" class="gh-home-post-feed">
-    {{#foreach posts}}
-        <article class="gh-home-post-card">
-            <a href="{{url}}">
-            {{#if feature_image}}
-                <img src="{{feature_image}}" alt="{{title}}">
-            {{else}}
-                <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
-            {{/if}}
-            </a>
-            <h3 class="gh-home-post-title">{{title}}</h3>
-            <time class="gh-home-post-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="YYYY.MM.DD"}}</time>
-        </article>
-    {{/foreach}}
-    </div>
-    {{pagination}}
+	<h2>Articles</h2>
+	<div id="post-feed" class="gh-home-post-feed">
+		{{#foreach posts}}
+			<article class="gh-home-post-card">
+				<a href="{{url}}">
+					{{#if feature_image}}
+						<img src="{{feature_image}}" alt="{{title}}" />
+					{{else}}
+						<img
+							src="{{asset 'images/default_post_feature_img.png'}}"
+							alt="{{title}}"
+						/>
+					{{/if}}
+				</a>
+				<h3 class="gh-home-post-title">{{title}}</h3>
+				<time
+					class="gh-home-post-date"
+					datetime="{{date format="YYYY-MM-DD"}}"
+				>{{date format="YYYY.MM.DD"}}</time>
+			</article>
+		{{/foreach}}
+	</div>
+	{{pagination}}
 </section>

--- a/home.hbs
+++ b/home.hbs
@@ -1,11 +1,6 @@
 {{!< default}}
 {{!-- The tag above means: insert everything in this file into the body of the default.hbs template --}}
-
 {{> "components/header" headerStyle=@custom.header_style}}
-
 {{> "components/gallery-thum"　}}
-
-
 {{> "components/home-post-list"}}
-
 {{> "question-answer-cta" }}

--- a/package.json
+++ b/package.json
@@ -127,13 +127,6 @@
 				"default": "Landing",
 				"group": "homepage"
 			},
-			"background_image": {
-				"type": "boolean",
-				"default": true,
-				"description": "Use the publication cover set on the Brand tab as your background",
-				"group": "homepage",
-				"visibility": "header_style:[Landing, Search]"
-			},
 			"show_featured_posts": {
 				"type": "boolean",
 				"default": false,

--- a/partials/components/navigation.hbs
+++ b/partials/components/navigation.hbs
@@ -27,9 +27,6 @@
                     {{#is "home"}}
                         <h1>Home</h1>
                     {{/is}}
-                    {{#is "articles"}}
-                        <h1>Articles</h1>
-                    {{/is}}
                     {{#primary_author}}
                         <h1>Author</h1>
                     {{/primary_author}}

--- a/partials/content-cta.hbs
+++ b/partials/content-cta.hbs
@@ -17,9 +17,9 @@
 
 		{{#has visibility="tiers"}}
 			<h2>この先は
-				{{#each tiers}}
+				{{#foreach tiers}}
 					{{name}}プラン
-				{{/each}} 限定
+				{{/foreach}} 限定
 			</h2>
 			{{#if @member}}
 				<a class="gh-post-upgrade-signup-link" href="#/portal/signup" data-portal="signup">


### PR DESCRIPTION
## pull requestの目的
Homeページ、Airticlesページのmeta情報を設定する

結果
- Homeページ：Ghost Admin > Setting > General settings > Title & descriptionから設定
  - PostsやPagesからは上書きできなかった
- Airticlesページ：Ghost Admin > Pagesで Airticlesを作成（中身は空）> Meta dataから設定

## やったこと

### Homeのmeta情報
- Ghost Admin > Setting > General settings > Title & descriptionから設定し、Homeのmeta情報を設定

### Airticlesのmeta情報
- articlesのroutes.yamlにdataプロパティを追加
```yaml
  /articles/:
    data: page.articles #追加
    controller: channel
    template: articles
    content_type: html
    limit: 10
```

- Ghost Admin > Pagesで Airticlesを作成
- 作成したPageのMeta dataから設定
- headerのAirticles固有のタイトル表記を削除
  - Pagesになるので重複する

## 特に確認してほしいところ
HomeとAirticlesにAdminで設定したmeta情報が反映されているか

## 気になったところ
- Q&Aページのmeta情報も確認しておきます
- Adminでテーマファイルのエラー出てたので対応しました
- 新しくページのindex生やすときはPagesで作っちゃったほうが良さそう（Q&Aでもそうしてもらったように）
