### PR TITLE
Q&A回答記事が1件もない場合、homeから最新のQ&Aを見る のボタンを非表示にする

### DIFF
--- a/partials/question-answer-cta.hbs
+++ b/partials/question-answer-cta.hbs
@@ -13,12 +13,15 @@
 					{{t "🏀 質問を投稿する ⛹️"}}
 				</a>
 			</div>
-			<a class="gh-home-qa-latest-articles" href="/tag/qa/">
-				<div >
-					{{t "✉️ 最新のQ&Aを見る ✉️"}}
-				</div>
-			</a>
-
+			{{#get "posts" filter="tag:qa" limit="1"}}
+				{{#if posts.length}}
+					<a class="gh-home-qa-latest-articles" href="/tag/qa/">
+					<div>
+						{{t "✉️ 最新のQ&Aを見る ✉️"}}
+					</div>
+					</a>
+				{{/if}}
+			{{/get}}
         </div>
     </div>
 </section>


### PR DESCRIPTION
## pull requestの目的
Q&A回答記事が1件もない場合、homeから最新のQ&Aを見る のボタンを非表示にする

## やったこと
- feat: slugが「qa」のtagがついた記事が1件以上ある場合のみ、最新のQ&Aを見る のCTAを表示する

## 特に確認してほしいところ
- Q&A（slugがqa）タグがついた既存の公開された記事が、
  - 1つ以上ある -> ボタンが表示される
  - 0 -> ボタンが表示されない

## 気になったところ