### PR TITLE
member.paid以外の時の記事一覧の表示順を変更する

### DIFF
--- a/articles.hbs
+++ b/articles.hbs
@@ -11,7 +11,7 @@
 <section class="gh-all-articles">
     <h2>Articles</h2>
     {{#if @member.paid}}
-        <div id="post-feed" class="gh-home-post-feed">
+        <div id="post-feed" class="gh-home-post-feed" data-member-status="paid">
             {{#foreach posts }}
                 <article class="gh-home-post-card">
                     <a href="{{url}}">
@@ -28,21 +28,57 @@
         </div>
         {{pagination}}
     {{else}}
-        <div id="post-feed" class="gh-home-post-feed">
-            {{#foreach posts limit="4"}}
-                <article class="gh-home-post-card">
-                    <a href="{{url}}">
-                    {{#if feature_image}}
-                        <img src="{{feature_image}}" alt="{{title}}">
-                    {{else}}
-                        <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
-                    {{/if}}
-                    </a>
-                    <h3 class="gh-home-post-title">{{title}}</h3>
-                    <time class="gh-home-post-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="YYYY.MM.DD"}}</time>
-                </article>
-            {{/foreach}}
+        <div id="post-feed" class="gh-home-post-feed" data-member-status="free">
+            {{!-- 無料記事の取得 --}}
+            {{#get "posts" filter="visibility:public" limit="4"}}
+                {{#foreach posts}}
+                    <article class="gh-home-post-card">
+                        <a href="{{url}}">
+                        {{#if feature_image}}
+                            <img src="{{feature_image}}" alt="{{title}}">
+                        {{else}}
+                            <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
+                        {{/if}}
+                        </a>
+                        <h3 class="gh-home-post-title">{{title}}</h3>
+                        <time class="gh-home-post-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="YYYY.MM.DD"}}</time>
+                    </article>
+                {{/foreach}}
+            {{/get}}
+            {{!-- 有料記事を取得 --}}
+            {{#get "posts" filter="visibility:paid" limit="4"}}
+                {{#foreach posts}}
+                    <article class="gh-home-post-card">
+                        <a href="{{url}}">
+                        {{#if feature_image}}
+                            <img src="{{feature_image}}" alt="{{title}}">
+                        {{else}}
+                            <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
+                        {{/if}}
+                        </a>
+                        <h3 class="gh-home-post-title">{{title}}</h3>
+                        <time class="gh-home-post-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="YYYY.MM.DD"}}</time>
+                    </article>
+                {{/foreach}}
+            {{/get}}
         </div>
         {{> "articles-cta"}}
+        <script>
+            document.addEventListener("DOMContentLoaded", function() {
+                // data-member-status 属性を確認して、ユーザーのステータスを取得
+                const postFeed = document.getElementById('post-feed');
+                const memberStatus = postFeed.getAttribute('data-member-status');
+
+                // 無料ユーザー (free) の場合のみ処理を実行
+                if (memberStatus === 'free') {
+                    const postCards = document.querySelectorAll('.gh-home-post-card');
+                    if (postCards.length > 4) {
+                        for (let i = 4; i < postCards.length; i++) {
+                            postCards[i].style.display = 'none';
+                        }
+                    }
+                }
+            });
+        </script>
     {{/if}}
 </section>

--- a/partials/components/home-post-list.hbs
+++ b/partials/components/home-post-list.hbs
@@ -14,6 +14,7 @@
 
         <div class="gh-home-post-feed">
             {{#if @member.paid}}
+                {{!-- 有料メンバーの場合は4件取得 --}}
                 {{#get "posts" include="authors" limit="4"}}
                     {{#foreach posts}}
                         <article class="gh-home-post-card">
@@ -35,7 +36,8 @@
                     {{/foreach}}
                 {{/get}}
             {{else}}
-                {{#get "posts" include="authors" limit="2"}}
+                {{!-- 無料メンバーの場合は、無料2件＋有料2件取得 --}}
+                {{#get "posts" filter="visibility:public" include="authors" limit="2"}}
                     {{#foreach posts}}
                         <article class="gh-home-post-card">
                             <a href="{{url}}">
@@ -55,7 +57,41 @@
                         </article>
                     {{/foreach}}
                 {{/get}}
+                
+                {{#get "posts" filter="visibility:paid" include="authors" limit="2"}}
+                    {{#foreach posts}}
+                        <article class="gh-home-post-card">
+                            <a href="{{url}}">
+                                {{#if feature_image}}
+                                    <img src="{{feature_image}}" alt="{{title}}">
+                                {{else}}
+                                    <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
+                                {{/if}}
+                            </a>
+                            <h3 class="gh-home-post-title">{{title}}</h3>
+                            <div class="gh-home-post-meta">
+                                <span>date</span>
+                                <time class="gh-home-post-date" datetime="{{date format="YYYY-MM-DD"}}">
+                                    {{date format="YYYY.MM.DD"}}
+                                </time>
+                            </div>
+                        </article>
+                    {{/foreach}}
+                {{/get}}
+                <script>
+                    document.addEventListener("DOMContentLoaded", function() {
+                        const postCards = document.querySelectorAll('.gh-home-post-card');
+
+                        // 無料ユーザーの場合、3件目以降の投稿を非表示にする
+                        if (postCards.length > 2) {
+                            for (let i = 2; i < postCards.length; i++) {
+                                postCards[i].style.display = 'none';
+                            }
+                        }
+                    });
+                </script>
             {{/if}}
         </div>
     </div>
+
 </section>

--- a/post.hbs
+++ b/post.hbs
@@ -54,28 +54,93 @@
 {{/post}}
 
 {{#if @custom.show_related_articles}}
-    {{#get "posts" include="authors" filter="id:-{{post.id}}" limit="2" as |next|}}
-        {{#if next}}
-            <section class="recommend-container">
-                <div class="recommend-container-inner">
-                    <h2 class="recommend-container-title">You may also like</h2>
-                    <div class="recommend-feed">
-                        {{#foreach posts}}
+    {{!-- 有料メンバーの場合 --}}
+    {{#if @member.paid}}
+        {{#get "posts" include="authors" filter="id:-{{post.id}}" limit="2" as |next|}}
+            {{#if next}}
+                <section class="recommend-container">
+                    <div class="recommend-container-inner">
+                        <h2 class="recommend-container-title">You may also like</h2>
+                        <div class="recommend-feed">
+                            {{#foreach posts}}
+                                <article class="recommend-post-card">
+                                    <a href="{{url}}">
+                                        {{#if feature_image}}
+                                            <img src="{{feature_image}}" alt="{{title}}">
+                                        {{else}}
+                                            <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
+                                        {{/if}}
+                                    </a>
+                                    <h3 class="recommend-post-title">{{title}}</h3>
+                                    <time class="recommend-post-date" datetime="{{date format="YYYY-MM-DD"}}">
+                                        {{date format="YYYY.MM.DD"}}
+                                    </time>
+                                </article>
+                            {{/foreach}}
+                        </div>
+                    </div>
+                </section>
+            {{/if}}
+        {{/get}}
+    {{!-- 無料メンバーの場合 --}}
+    {{else}}
+        <section class="recommend-container">
+            <div class="recommend-container-inner">
+                <h2 class="recommend-container-title">You may also like</h2>
+                <div id="recommend-feed" class="recommend-feed">
+                    {{!-- 無料記事を2件取得 --}}
+                    {{#get "posts" filter="visibility:public+id:-{{post.id}}" limit="2" as |freePosts|}}
+                        {{#foreach freePosts}}
                             <article class="recommend-post-card">
                                 <a href="{{url}}">
                                     {{#if feature_image}}
-                                    <img src="{{feature_image}}" alt="{{title}}">
+                                        <img src="{{feature_image}}" alt="{{title}}">
                                     {{else}}
                                         <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
                                     {{/if}}
                                 </a>
                                 <h3 class="recommend-post-title">{{title}}</h3>
-                                <time class="recommend-post-date" datetime="{{date format="YYYY-MM-DD"}}">date {{date format="YYYY.MM.DD"}}</time>
+                                <time class="recommend-post-date" datetime="{{date format="YYYY-MM-DD"}}">
+                                    {{date format="YYYY.MM.DD"}}
+                                </time>
                             </article>
                         {{/foreach}}
-                    </div>
+                    {{/get}}
+
+                    {{!-- 有料記事を2件取得 --}}
+                    {{#get "posts" filter="visibility:paid+id:-{{post.id}}" limit="2" as |paidPosts|}}
+                        {{#foreach paidPosts}}
+                            <article class="recommend-post-card">
+                                <a href="{{url}}">
+                                    {{#if feature_image}}
+                                        <img src="{{feature_image}}" alt="{{title}}">
+                                    {{else}}
+                                        <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
+                                    {{/if}}
+                                </a>
+                                <h3 class="recommend-post-title">{{title}}</h3>
+                                <time class="recommend-post-date" datetime="{{date format="YYYY-MM-DD"}}">
+                                    {{date format="YYYY.MM.DD"}}
+                                </time>
+                            </article>
+                        {{/foreach}}
+                    {{/get}}
                 </div>
-            </section>
-        {{/if}}
-    {{/get}}
+            </div>
+        </section>
+
+        <script>
+            document.addEventListener("DOMContentLoaded", function() {
+                const recommendFeed = document.getElementById('recommend-feed');
+                const posts = recommendFeed.querySelectorAll('.recommend-post-card');
+
+                // 3件目以降の投稿を非表示にする
+                if (posts.length > 2) {
+                    for (let i = 2; i < posts.length; i++) {
+                        posts[i].style.display = 'none';
+                    }
+                }
+            });
+        </script>
+    {{/if}}
 {{/if}}


### PR DESCRIPTION
## pull requestの目的
無料ユーザーおよび未ログインユーザー（＝有料ユーザーではない）時に、記事一覧に表示される記事の表示順序を変更する

## やったこと
- 以下に従い並び順を変更する
  - home の記事一覧
    - 表示件数２件 → 無料記事2 * 有料記事2 を取得し（必要最大件数4）、３件目以降は非表示
  - articles の記事一覧
    - 表示件数4件 → 無料記事4 * 有料記事4 を取得し（必要最大件数8）、4件目以降は非表示にする
  - post 内のサジェスト記事一覧
    - 表示件数２件 → 無料記事2 * 有料記事2 を取得し（必要最大件数4）、３件目以降は非表示

## 特に確認してほしいところ
- 有料ユーザーの時は、更新順に投稿が並んでいるか
- 無料ユーザーの時は、上記に従い、無料記事が先に表示されているか

## 気になったところ