### PR TITLE
無料メンバーでの記事一覧の表示順の修正

### DIFF
--- a/articles.hbs
+++ b/articles.hbs
@@ -1,6 +1,6 @@
 {{!< default}}
 <section class="gh-all-articles-tags-section">
-    {{#get "tags" limit="all"}}
+    {{#get "tags" filter="slug:-free" limit="all"}}
         <div class="gh-all-article-tags">
         {{#foreach tags}}
             <a class="gh-all-article-tag" href="{{url}}">{{name}}</a>
@@ -30,7 +30,7 @@
     {{else}}
         <div id="post-feed" class="gh-home-post-feed" data-member-status="free">
             {{!-- 無料記事の取得 --}}
-            {{#get "posts" filter="visibility:public" limit="4"}}
+            {{#get "posts" filter="tags:'free'" limit="4"}}
                 {{#foreach posts}}
                     <article class="gh-home-post-card">
                         <a href="{{url}}">

--- a/articles.hbs
+++ b/articles.hbs
@@ -29,24 +29,8 @@
         {{pagination}}
     {{else}}
         <div id="post-feed" class="gh-home-post-feed" data-member-status="free">
-            {{!-- 無料記事の取得 --}}
+            {{!-- 無料タグ付き記事の取得 --}}
             {{#get "posts" filter="tags:'free'" limit="4"}}
-                {{#foreach posts}}
-                    <article class="gh-home-post-card">
-                        <a href="{{url}}">
-                        {{#if feature_image}}
-                            <img src="{{feature_image}}" alt="{{title}}">
-                        {{else}}
-                            <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
-                        {{/if}}
-                        </a>
-                        <h3 class="gh-home-post-title">{{title}}</h3>
-                        <time class="gh-home-post-date" datetime="{{date format="YYYY-MM-DD"}}">{{date format="YYYY.MM.DD"}}</time>
-                    </article>
-                {{/foreach}}
-            {{/get}}
-            {{!-- 有料記事を取得 --}}
-            {{#get "posts" filter="visibility:paid" limit="4"}}
                 {{#foreach posts}}
                     <article class="gh-home-post-card">
                         <a href="{{url}}">
@@ -63,22 +47,5 @@
             {{/get}}
         </div>
         {{> "articles-cta"}}
-        <script>
-            document.addEventListener("DOMContentLoaded", function() {
-                // data-member-status 属性を確認して、ユーザーのステータスを取得
-                const postFeed = document.getElementById('post-feed');
-                const memberStatus = postFeed.getAttribute('data-member-status');
-
-                // 無料ユーザー (free) の場合のみ処理を実行
-                if (memberStatus === 'free') {
-                    const postCards = document.querySelectorAll('.gh-home-post-card');
-                    if (postCards.length > 4) {
-                        for (let i = 4; i < postCards.length; i++) {
-                            postCards[i].style.display = 'none';
-                        }
-                    }
-                }
-            });
-        </script>
     {{/if}}
 </section>

--- a/partials/components/home-post-list.hbs
+++ b/partials/components/home-post-list.hbs
@@ -36,7 +36,7 @@
                     {{/foreach}}
                 {{/get}}
             {{else}}
-                {{!-- 無料メンバーの場合は、無料2件＋有料2件取得 --}}
+                {{!-- 無料タグ付き記事の取得 --}}
                 {{#get "posts" filter="tags:'free'" include="authors" limit="2"}}
                     {{#foreach posts}}
                         <article class="gh-home-post-card">
@@ -57,39 +57,6 @@
                         </article>
                     {{/foreach}}
                 {{/get}}
-                
-                {{#get "posts" filter="visibility:paid" include="authors" limit="2"}}
-                    {{#foreach posts}}
-                        <article class="gh-home-post-card">
-                            <a href="{{url}}">
-                                {{#if feature_image}}
-                                    <img src="{{feature_image}}" alt="{{title}}">
-                                {{else}}
-                                    <img src="{{asset "images/default_post_feature_img.png"}}" alt="{{title}}">
-                                {{/if}}
-                            </a>
-                            <h3 class="gh-home-post-title">{{title}}</h3>
-                            <div class="gh-home-post-meta">
-                                <span>date</span>
-                                <time class="gh-home-post-date" datetime="{{date format="YYYY-MM-DD"}}">
-                                    {{date format="YYYY.MM.DD"}}
-                                </time>
-                            </div>
-                        </article>
-                    {{/foreach}}
-                {{/get}}
-                <script>
-                    document.addEventListener("DOMContentLoaded", function() {
-                        const postCards = document.querySelectorAll('.gh-home-post-card');
-
-                        // 無料ユーザーの場合、3件目以降の投稿を非表示にする
-                        if (postCards.length > 2) {
-                            for (let i = 2; i < postCards.length; i++) {
-                                postCards[i].style.display = 'none';
-                            }
-                        }
-                    });
-                </script>
             {{/if}}
         </div>
     </div>

--- a/partials/components/home-post-list.hbs
+++ b/partials/components/home-post-list.hbs
@@ -37,7 +37,7 @@
                 {{/get}}
             {{else}}
                 {{!-- 無料メンバーの場合は、無料2件＋有料2件取得 --}}
-                {{#get "posts" filter="visibility:public" include="authors" limit="2"}}
+                {{#get "posts" filter="tags:'free'" include="authors" limit="2"}}
                     {{#foreach posts}}
                         <article class="gh-home-post-card">
                             <a href="{{url}}">

--- a/post.hbs
+++ b/post.hbs
@@ -144,18 +144,18 @@
                 }
             });
         </script>
-        <script>
-            document.addEventListener("DOMContentLoaded", function() {
-                const tags = document.querySelectorAll('.gh-article-tag');
-
-                tags.forEach(tag => {
-                    const slug = tag.getAttribute('data-slug');
-                    // slug が "free" でない場合、タグを表示
-                    if (slug !== "free") {
-                        tag.style.display = "inline-block";
-                    }
-                });
-            });
-        </script>
     {{/if}}
 {{/if}}
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        const tags = document.querySelectorAll('.gh-article-tag');
+
+        tags.forEach(tag => {
+            const slug = tag.getAttribute('data-slug');
+            // slug が "free" でない場合、タグを表示
+            if (slug !== "free") {
+                tag.style.display = "inline-block";
+            }
+        });
+    });
+</script>

--- a/post.hbs
+++ b/post.hbs
@@ -22,11 +22,13 @@
             </div>
             {{/if}}
 
-            <div class="gh-article-tags">
-                {{#foreach tags}}
-                    <a class="gh-article-tag" href="{{url}}">{{name}}</a>
-                {{/foreach}}
-            </div>
+            {{#if tags}}
+                <div class="gh-article-tags">
+                    {{#foreach tags}}
+                        <a class="gh-article-tag" href="{{url}}" data-slug="{{slug}}" style="display: none;">{{name}}</a>
+                    {{/foreach}}
+                </div>
+            {{/if}}
 
         </header>
 
@@ -140,6 +142,19 @@
                         posts[i].style.display = 'none';
                     }
                 }
+            });
+        </script>
+        <script>
+            document.addEventListener("DOMContentLoaded", function() {
+                const tags = document.querySelectorAll('.gh-article-tag');
+
+                tags.forEach(tag => {
+                    const slug = tag.getAttribute('data-slug');
+                    // slug が "free" でない場合、タグを表示
+                    if (slug !== "free") {
+                        tag.style.display = "inline-block";
+                    }
+                });
             });
         </script>
     {{/if}}


### PR DESCRIPTION
## Notion タスク
[無料メンバーでの記事一覧の表示順の修正](https://www.notion.so/melty-inc/14a7bdbab28380fd84f5e3c69b36e537?pvs=4)

## やったこと
- 無料メンバーの場合、無料メンバーの一覧に表示したいタグがついたPostを取得し一覧に表示する
  - 無料メンバーのPost一覧に表示したいタグのslug: `free` （タグの名前はなんでも大丈夫）
  -  無料メンバーのPost一覧に表示するロジックを以下のように変更
    - slug = freeのタグがついたPostのみを表示する（Articlesでは最大４件、トップでは最大２件。最大に満たない場合の補完はしない）
- slug = freeのタグが記事一覧ページに表示されないようにする
- slug = freeのタグが記事詳細ページに表示されないようにする
  - Postに紐づくタグをサーバー側で条件分岐で取得することができないため、Postに紐づくタグ全てを取得した上で、クライアント側（Javascript）で表示・非表示の処理をすることになる
    - Javascriptで非表示に変更とする場合は、一瞬タグが見えてしまうため、逆に全てのタグを一旦非表示で取得し、Javascriptでfreeタグ以外を表示にする

## 確認して欲しいこと
- 無料メンバーの時に、 slug = freeのタグがついた記事のみが表示されているか
- 有料メンバーの時は、これまでと変わりなく全ての記事が更新日の降順で表示されるか
- slug = freeのタグが記事一覧ページに表示されないか
- slug = freeのタグが記事詳細ページに表示されないか