### PR TITLE
テーマファイルからメールテンプレートを上書きできるようにする

### DIFF
--- a/docs/CustomizeMailTemplate.md
+++ b/docs/CustomizeMailTemplate.md
@@ -1,0 +1,114 @@
+# メールテンプレートのカスタマイズの方法（暫定対応）
+メールテンプレートをカスタマイズしたい場合は、下記の表に従い、”メールテンプレートカスタマイズ用ファイル名”のファイルを配置する。
+- 配置先：`ghost/core/content/themes/source/partials/email-templates/`
+
+また、メールの件名をカスタマイズしたい場合は、下記の表に従い、以下のファイルに”メール件名カスタマイズ用変数名”を追加する。
+- メール件名カスタマイズ用ファイル：`ghost/core/content/themes/source/partials/email-templates/subjects.js`
+- `subjects.js`サンプル
+    ``` jacascrpt
+    const signin = () => {
+        return 'ログインのご案内';
+    };
+
+    const subscribe = () => {
+        return 'サブスクリプション登録の確認';
+    };
+
+    const signup = () => {
+        return '新規登録のご案内';
+    };
+
+    const signupPaid = () => {
+        return 'ご登録いただきありがとうございます';
+    };
+
+    const updateEmail = () => {
+        return 'メールアドレスのご確認';
+    };
+
+    /**
+    * Generates a subject for a new comment email.
+    *
+    * @param {string} postTitle - The title of the post.
+    * @returns {string} The subject for the new comment email.
+    */
+    const newComment = ({postTitle}) => {
+        return `${postTitle}に新しいコメントがありました`;
+    };
+
+    /**
+    * Generates a subject for a new comment reply email.
+    *
+    * @param {string} postTitle - The title of the post.
+    * @returns {string} The subject for the new comment reply email.
+    */
+    const newCommentReply = ({postTitle}) => {
+        return `${postTitle}に返信コメントがつきました`;
+    };
+
+    /**
+    * Generates a subject for a report email.
+    *
+    * @param {string} postTitle - The title of the post.
+    * @returns {string} The subject for the report email.
+    */
+    const report = ({postTitle}) => {
+        return `${postTitle}に報告があります`;
+    };
+
+    /**
+    * Generates a subject for a newsletter email.
+    *
+    * @param {string} postTitle - The title of the post.
+    * @returns {string} The subject for the newsletter email.
+    */
+    const newsletter = ({postTitle}) => {
+        return `${postTitle}が配信されたました`;
+    };
+
+    module.exports = {
+        signin,
+        subscribe,
+        signup,
+        signupPaid,
+        updateEmail,
+        newComment,
+        newCommentReply,
+        report,
+        newsletter
+    };
+    ```
+
+## カスタマイズできるメールテンプレートとファイル名
+| 役割                                       | メールテンプレートカスタマイズ元ファイルパス                                    | メールテンプレートカスタマイズ用ファイル名                       | メール件名カスタマイズ用変数名   |
+| ------------------------------------------ | --------------------------------------------------------------------------- | --------------------------------------------------------------- | ------------------------------ |
+| サインイン時のメールアドレス認証             | ghost/core/core/server/services/members/emails/signin.js                   | partials/email-templates/signin.js                             | signin                         |
+| 無料サインアップ時のメールアドレス認証       | ghost/core/core/server/services/members/emails/signup.js                   | partials/email-templates/signup.js                             | signup                         |
+| 有料サインアップ時のメールアドレス認証       | ghost/core/core/server/services/members/emails/signup-paid.js              | partials/email-templates/signup-paid.js                        | signupPaid                     |
+| サブスク登録時のサンクスメール               | ghost/core/core/server/services/members/emails/subscribe.js                | partials/email-templates/subscribe.js                          | subscribe                      |
+| メールアドレス更新時の確認                   | ghost/core/core/server/services/members/emails/update-email.js             | partials/email-templates/update-email.js                       | updateEmail                    |
+| Postに新しいコメントが付いたときの通知       | ghost/core/core/server/services/comments/email-templates/new-comment.hbs    | partials/email-templates/new-comment.hbs                       | newComment                     |
+| コメントに新しいリプライが付いたときの通知   | ghost/core/core/server/services/comments/email-templates/new-comment-reply.hbs | partials/email-templates/new-comment-reply.hbs                 | newCommentReply                |
+| 報告されたコメントがあったときの通知         | ghost/core/core/server/services/comments/email-templates/report.hbs         | partials/email-templates/report.hbs                            | report                         |
+| Postが投稿されたときの通知                  | ghost/email-service/lib/email-templates/template.hbs                       | partials/email-templates/newsletter.hbs                        | newsletter                     |
+| 一時的な寄付を受けたときの通知（推測）       | ghost/staff-service/lib/email-templates/donation.hbs                       | partials/email-templates/donation.hbs                          | donation                       |
+| 新規の無料サインアップがあったときの通知     | ghost/staff-service/lib/email-templates/new-free-signup.hbs                | partials/email-templates/new-free-signup.hbs                   | newFreeSignup                  |
+| 新規の有料サインアップがあったときの通知     | ghost/staff-service/lib/email-templates/new-paid-started.hbs               | partials/email-templates/new-paid-started.hbs                  | newPaidStarted                 |
+| 有料メンバーが解約したときの通知             | ghost/staff-service/lib/email-templates/new-paid-cancellation.hbs          | partials/email-templates/new-paid-cancellation.hbs             | newPaidCancellation            |
+
+
+## 作業フロー
+### メールテンプレートのカスタマイズ
+1. カスタマイズしたいメールテンプレートを表から確認する
+2. 表のカスタマイズ元ファイルディレクトリとファイル名から、元ファイルを特定する
+3. 元ファイルをカスタマイズ用ファイル名で、`ghost/core/content/themes/source/partials/email-templates/`配下にコピーする
+4. コピーしたファイルを編集し、保存する
+
+### メール件名のカスタマイズ
+1. `partials/email-templates/subjects.js`を作成する
+2. 表の「メール件名カスタマイズ用」を確認する
+3. `partials/email-templates/subjects.js`に変数名を追加する（サンプル参照）
+
+注意:
+- カスタマイズ時に使えるhelperや引数は、元のファイルを参照すること。基本的に元ファイルで使われていないものは使えないです。
+- どうしても元ファイルで使われていないhelperや引数を使用したい場合は、開発に相談してください。

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 
 - [Node.js](https://nodejs.org/): v18.20.4
 - [Yarn](https://yarnpkg.com/): v1.22.22
-- [ローカルのGhost環境](https://github.com/magaport/DIS-Ghost): yw-japanese ブランチ
+- [ローカルのGhost環境](https://github.com/magaport/Unleash): yw-japanese ブランチ
   - `ghost/core/content/themes`以下の`source`ディレクトリを本リポジトリに置換する
 
 &nbsp;
@@ -21,7 +21,7 @@
    yarn install
    ```
 
-- serverの起動  
+- serverの起動 
   - `/assets/css/` ファイルを編集できるようになり、自動的に `/assets/built/` にコンパイルされる
 
    ```bash
@@ -39,6 +39,7 @@
 
 - [Handlebars](http://handlebarsjs.com/)
 - [theme API documentation](https://ghost.org/docs/themes/)
+- [メールテンプレートのカスタマイズの方法（暫定対応）](CustomizeMailTemplate.md)
 
 ## Production Deployment Flow
 

--- a/partials/email-templates/new-comment-reply.hbs
+++ b/partials/email-templates/new-comment-reply.hbs
@@ -1,0 +1,237 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- タイトルを日本語に変更 -->
+    <title>「{{postTitle}}」に返信コメントがつきました【Locker Room │ 渡邊雄太公式ファンコミュニティ】</title>
+    <style>
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+      table[class=body] ul,
+      table[class=body] ol,
+      table[class=body] td,
+      table[class=body] span,
+      table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+      table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+      table[class=body] p[class=small],
+      table[class=body] a[class=small] {
+        font-size: 11px !important;
+      }
+    }
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+      .recipient-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+    }
+    hr {
+      border-width: 0;
+      height: 0;
+      margin-top: 34px;
+      margin-bottom: 34px;
+      border-bottom-width: 1px;
+      border-bottom-color: #EEF5F8;
+    }
+    a {
+      color: #15212A;
+    }
+    blockquote {
+      margin-left: 0;
+      padding-left: 20px;
+      border-left: 3px solid #DDE1E5;
+    }
+    </style>
+  </head>
+  <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="width: 100%;">
+      <tr>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="display: block; margin: 0 auto; max-width: 540px; padding: 10px; width: 540px; font-size: 14px; vertical-align: top;">
+          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED CONTAINER -->
+            <span class="preheader" style="display: none; opacity: 0; overflow: hidden; visibility: hidden;">
+              {{postTitle}}へのコメントに返信がありました
+            </span>
+            <table class="main" style="width: 100%; background: #ffffff; border-radius: 8px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
+                    <tr>
+                      <td style="font-size: 14px; vertical-align: top;">
+
+                        <!-- 本文ここから -->
+                        <p style="font-size: 16px; color: #3A464C; margin: 0; margin-bottom: 24px; line-height: 1.8;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティです。<br><br>
+                          「{{postTitle}}」に返信コメントがつきました。
+                        </p>
+
+                        <!-- 返信者情報 -->
+                        <table width="100" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="width: 100%; min-width: 100%; background: #F9F9FA; border-radius: 7px;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding: 16px;">
+                                <table border="0" cellpadding="0" cellspacing="0">
+                                  <tr>
+                                    <!-- アイコン部分 -->
+                                    <td style="padding-right: 8px;">
+                                      <div style="width: 44px; height: 44px; background-color: #15171A; border-radius: 999px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 16px; color: #FFFFFF; text-align: center; font-weight: 500; line-height: 42px;">
+                                        {{memberInitials}}
+                                      </div>
+                                    </td>
+                                    <!-- 名前、日付部分 -->
+                                    <td style="padding-right: 8px;">
+                                      <p style="font-size: 16px; margin: 0; color: #15171A; font-weight: 600;">
+                                        {{memberName}}
+                                      </p>
+                                      <p style="font-size: 13px; margin: 0; color: #95A1AD;">
+                                        {{#if memberExpertise}}{{memberExpertise}} &#8226; {{/if}}{{replyDate}}
+                                      </p>
+                                    </td>
+                                  </tr>
+                                </table>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td align="left" style="font-size: 16px; color: #15171A; vertical-align: top; padding: 0 16px 16px 16px;">
+                                {{{replyHtml}}}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <!-- ボタン: コメントを見る -->
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="width: 100%; box-sizing: border-box;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding-top: 32px; padding-bottom: 12px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="background-color: {{accentColor}}; border-radius: 5px; text-align: center;">
+                                        <a href="{{postUrl}}#ghost-comments"
+                                          target="_blank"
+                                          style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; margin: 0; padding: 9px 22px;">
+                                          コメントを見る
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <hr style="margin-top: 32px; margin-bottom: 24px; border-bottom: 1px solid #EEF5F8; border-width: 0;">
+
+                        <p style="font-size: 15px; margin: 0; color: #3A464C; line-height: 1.8; margin-bottom: 8px;">
+                          以下のURLをブラウザにコピー＆ペーストいただくことでも確認が可能です。<br>
+                          <a href="{{postUrl}}#ghost-comments" style="text-decoration: underline; color: #3A464C;">{{postUrl}}#ghost-comments</a>
+                        </p>
+
+                        <p style="font-size: 14px; margin: 0; margin-top: 24px; line-height: 1.8; color: #3A464C;">
+                          ※コメントの返信の際のメール通知を停止するには、
+                          <a href="{{profileUrl}}" style="text-decoration: underline; color: #3A464C;">
+                            プロフィールのメール設定
+                          </a>
+                          からオフにしてください。
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+                        <!-- フッター -->
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 4px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティ
+                        </p>
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 24px;">
+                          <a href="https://yuta-watanabe.com/" style="text-decoration: underline; color: #3A464C;">
+                            https://yuta-watanabe.com/
+                          </a>
+                        </p>
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0;">
+                          ※本メールは送信専用アドレスから自動送信されています。<br>
+                          本メールにご返信いただきましても、対応いたしかねます。
+                        </p>
+                        <!-- 本文ここまで -->
+
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <!-- END MAIN CONTENT AREA -->
+            </table>
+            <!-- END CENTERED CONTAINER -->
+          </div>
+        </td>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/partials/email-templates/new-comment.hbs
+++ b/partials/email-templates/new-comment.hbs
@@ -1,0 +1,237 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- タイトルを日本語に変更 -->
+    <title>【Locker Room │ 渡邊雄太公式ファンコミュニティ】コメント返信のお知らせ</title>
+    <style>
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+      table[class=body] ul,
+      table[class=body] ol,
+      table[class=body] td,
+      table[class=body] span,
+      table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+      table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+      table[class=body] p[class=small],
+      table[class=body] a[class=small] {
+        font-size: 11px !important;
+      }
+    }
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+      .recipient-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+    }
+    hr {
+      border-width: 0;
+      height: 0;
+      margin-top: 34px;
+      margin-bottom: 34px;
+      border-bottom-width: 1px;
+      border-bottom-color: #EEF5F8;
+    }
+    a {
+      color: #15212A;
+    }
+    blockquote {
+      margin-left: 0;
+      padding-left: 20px;
+      border-left: 3px solid #DDE1E5;
+    }
+    </style>
+  </head>
+  <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="width: 100%;">
+      <tr>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="display: block; margin: 0 auto; max-width: 540px; padding: 10px; width: 540px; font-size: 14px; vertical-align: top;">
+          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED CONTAINER -->
+            <span class="preheader" style="display: none; opacity: 0; overflow: hidden; visibility: hidden;">
+              {{postTitle}}へのコメントに返信がありました
+            </span>
+            <table class="main" style="width: 100%; background: #ffffff; border-radius: 8px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
+                    <tr>
+                      <td style="font-size: 14px; vertical-align: top;">
+
+                        <!-- 本文ここから -->
+                        <p style="font-size: 16px; color: #3A464C; margin: 0; margin-bottom: 24px; line-height: 1.8;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティです。<br><br>
+                          「{{postTitle}}」に返信コメントがつきました。
+                        </p>
+
+                        <!-- 返信者情報 -->
+                        <table width="100" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="width: 100%; min-width: 100%; background: #F9F9FA; border-radius: 7px;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding: 16px;">
+                                <table border="0" cellpadding="0" cellspacing="0">
+                                  <tr>
+                                    <!-- アイコン部分 -->
+                                    <td style="padding-right: 8px;">
+                                      <div style="width: 44px; height: 44px; background-color: #15171A; border-radius: 999px; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 16px; color: #FFFFFF; text-align: center; font-weight: 500; line-height: 42px;">
+                                        {{memberInitials}}
+                                      </div>
+                                    </td>
+                                    <!-- 名前、日付部分 -->
+                                    <td style="padding-right: 8px;">
+                                      <p style="font-size: 16px; margin: 0; color: #15171A; font-weight: 600;">
+                                        {{memberName}}
+                                      </p>
+                                      <p style="font-size: 13px; margin: 0; color: #95A1AD;">
+                                        {{#if memberExpertise}}{{memberExpertise}} &#8226; {{/if}}{{commentDate}}
+                                      </p>
+                                    </td>
+                                  </tr>
+                                </table>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td align="left" style="font-size: 16px; color: #15171A; vertical-align: top; padding: 0 16px 16px 16px;">
+                                {{{commentHtml}}}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <!-- ボタン: コメントを見る -->
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="width: 100%; box-sizing: border-box;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding-top: 32px; padding-bottom: 12px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="background-color: {{accentColor}}; border-radius: 5px; text-align: center;">
+                                        <a href="{{postUrl}}#ghost-comments"
+                                          target="_blank"
+                                          style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; margin: 0; padding: 9px 22px;">
+                                          コメントを見る
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <hr style="margin-top: 32px; margin-bottom: 24px; border-bottom: 1px solid #EEF5F8; border-width: 0;">
+
+                        <p style="font-size: 15px; margin: 0; color: #3A464C; line-height: 1.8; margin-bottom: 8px;">
+                          以下のURLをブラウザにコピー＆ペーストいただくことでも確認が可能です。<br>
+                          <a href="{{postUrl}}#ghost-comments" style="text-decoration: underline; color: #3A464C;">{{postUrl}}#ghost-comments</a>
+                        </p>
+
+                        <p style="font-size: 14px; margin: 0; margin-top: 24px; line-height: 1.8; color: #3A464C;">
+                          ※コメントの返信の際のメール通知を停止するには、
+                          <a href="{{profileUrl}}" style="text-decoration: underline; color: #3A464C;">
+                            プロフィールのメール設定
+                          </a>
+                          からオフにしてください。
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+                        <!-- フッター -->
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 4px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティ
+                        </p>
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 24px;">
+                          <a href="https://yuta-watanabe.com/" style="text-decoration: underline; color: #3A464C;">
+                            https://yuta-watanabe.com/
+                          </a>
+                        </p>
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0;">
+                          ※本メールは送信専用アドレスから自動送信されています。<br>
+                          本メールにご返信いただきましても、対応いたしかねます。
+                        </p>
+                        <!-- 本文ここまで -->
+
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <!-- END MAIN CONTENT AREA -->
+            </table>
+            <!-- END CENTERED CONTAINER -->
+          </div>
+        </td>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/partials/email-templates/newsletter.hbs
+++ b/partials/email-templates/newsletter.hbs
@@ -1,0 +1,319 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <!--[if mso]><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch><o:AllowPNG/></o:OfficeDocumentSettings></xml><![endif]-->
+    <title>{{post.title}} 【Locker Room │ 渡邊雄太公式ファンコミュニティ】</title>
+    {{>styles}}
+</head>
+
+<body>
+    <span class="preheader">{{preheader}}</span>
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body" width="100%">
+        <!-- Outlook doesn't respect max-width so we need an extra centered table -->
+        <!--[if mso]>
+            <tr>
+                <td>
+                    <center>
+                        <table border="0" cellpadding="0" cellspacing="0" width="600">
+            <![endif]-->
+        <tr>
+            <td>&nbsp;</td>
+            <td class="container">
+                <div class="content">
+                    <!-- START CENTERED WHITE CONTAINER -->
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main" width="100%">
+
+                        <!-- START MAIN CONTENT AREA -->
+                        <tr>
+                            <td class="wrapper">
+                                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                    {{#if headerImage}}
+                                    <tr class="header-image-row">
+                                        <td class="header-image" width="100%" align="center">
+                                            <a href="{{site.url}}">
+                                                <img src="{{headerImage}}" {{#if headerImageWidth}}
+                                                    width="{{headerImageWidth}}" {{/if}}>
+                                            </a>
+                                        </td>
+                                    </tr>
+                                    {{/if}}
+                                    {{#if (or showHeaderIcon showHeaderTitle showHeaderName) }}
+                                    <tr class="site-info-row">
+                                        <td class="site-info" width="100%" align="center">
+                                            <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                                {{#if (and showHeaderIcon site.iconUrl) }}
+                                                <tr>
+                                                    <td class="site-icon"><a href="{{site.url}}"><img
+                                                                src="{{site.iconUrl}}" alt="{{site.title}}" border="0"
+                                                                width="48" height="48"></a></td>
+                                                </tr>
+                                                {{/if}}
+                                                {{#if showHeaderTitle }}
+                                                <tr>
+                                                    <td
+                                                        class="site-url {{#unless showHeaderName}}site-url-bottom-padding{{/unless}}">
+                                                        <div style="width: 100% !important;"><a href="{{site.url}}"
+                                                                class="site-title">{{site.title}}</a></div>
+                                                    </td>
+                                                </tr>
+                                                {{/if}}
+                                                {{#if (and showHeaderName showHeaderTitle) }}
+                                                <tr>
+                                                    <td class="site-url site-url-bottom-padding">
+                                                        <div style="width: 100% !important;"><a href="{{site.url}}"
+                                                                class="site-subtitle">{{newsletter.name}}</a></div>
+                                                    </td>
+                                                </tr>
+                                                {{/if}}
+                                                {{#if (and showHeaderName (not showHeaderTitle)) }}
+                                                <tr>
+                                                    <td class="site-url site-url-bottom-padding">
+                                                        <div style="width: 100% !important;"><a href="{{site.url}}"
+                                                                class="site-title">{{newsletter.name}}</a></div>
+                                                    </td>
+                                                </tr>
+                                                {{/if}}
+
+                                            </table>
+                                        </td>
+                                    </tr>
+                                    {{/if}}
+
+                                    {{#if newsletter.showPostTitleSection}}
+                                    <tr>
+                                        <td class="{{classes.title}}">
+                                            <a href="{{post.url}}" class="{{classes.titleLink}}">{{post.title}}</a>
+                                        </td>
+                                    </tr>
+                                    {{#if (and newsletter.showExcerpt post.customExcerpt)}}
+                                    <tr>
+                                        <td class="post-excerpt-wrapper" style="width: 100%">
+                                            <p class="{{classes.excerpt}}">{{post.customExcerpt}}</p>
+                                        </td>
+                                    </tr>
+                                    {{/if}}
+                                    <tr>
+                                        <td style="width: 100%">
+                                            <table class="post-meta-wrapper" role="presentation" border="0"
+                                                cellpadding="0" cellspacing="0" width="100%"
+                                                style="padding-bottom: 32px;">
+                                                <tr>
+                                                    <td height="20" class="{{classes.meta}}" style="padding: 0;">
+                                                        {{post.authors}} • <span
+                                                            class="post-meta-date">{{post.publishedAt}} </span>
+                                                    </td>
+                                                    <td class="{{classes.meta}} view-online desktop">
+                                                        <a href="{{post.url}}" class="view-online-link">ブラウザで見る</a>
+                                                    </td>
+                                                </tr>
+                                                <tr class="{{classes.meta}} view-online-mobile">
+                                                    <td height="20" class="view-online">
+                                                        <a href="{{post.url}}" class="view-online-link">ブラウザで見る</a>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                    {{/if}}
+
+                                    {{#if showFeatureImage }}
+                                    <tr class="feature-image-row">
+                                        <td class="feature-image
+                                                    {{#if post.feature_image_caption }}
+                                                        feature-image-with-caption
+                                                    {{/if}}
+                                                " align="center"><img src="{{post.feature_image}}" {{#if
+                                                post.feature_image_width }} width="{{post.feature_image_width}}" {{/if}}
+                                                {{#if post.feature_image_alt }} alt="{{post.feature_image_alt}}"
+                                                {{/if}}></td>
+                                    </tr>
+
+                                    {{#if post.feature_image_caption }}
+                                    <tr>
+                                        <td align="center">
+                                            <div class="feature-image-caption">
+                                                {{{post.feature_image_caption}}}
+                                            </div>
+                                        </td>
+                                    </tr>
+                                    {{/if}}
+                                    {{/if}}
+                                    <tr class="post-content-row">
+                                        <td class="{{classes.body}}">
+                                            <!-- POST CONTENT START -->
+                                            {{{html}}}
+                                            <!-- POST CONTENT END -->
+
+                                            {{#if paywall}}
+                                                <div class="align-center" style="text-align: center;">
+                                                    <hr
+                                                        style="position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e5eff5;">
+                                                    <h2
+                                                        style="margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 26px;">
+                                                        <span
+                                                            style="white-space: nowrap; font-size: 20px!important;">続きを読むには、プランのアップグレードが必要です。</span>
+                                                    </h2>
+                                                    <div class="btn btn-accent"
+                                                        style="box-sizing: border-box; width: 100%; display: table;">
+                                                        <table border="0" cellspacing="0" cellpadding="0" align="center"
+                                                            style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                                                            <tbody>
+                                                                <tr>
+                                                                    <td align="center" valign="top"
+                                                                        bgcolor="{{accentColor}}"
+                                                                        style="vertical-align: top; text-align: center; border-radius: 5px;">
+                                                                        <a href="{{paywall.signupUrl}}"
+                                                                            style="overflow-wrap: anywhere; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; background-color: {{accentColor}}; border-color: {{accentColor}}; color: #FFFFFF;"
+                                                                            target="_blank">プランのアップグレード</a>
+                                                                    </td>
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                    </div>
+                                                    <p style="margin: 0 0 1.5em 0; line-height: 1.6em;"></p>
+                                                </div>
+
+                                            {{/if}}
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                        <!-- END MAIN CONTENT AREA -->
+
+                        {{#if (or feedbackButtons newsletter.showCommentCta) }}
+                        <tr>
+                            <td dir="ltr" width="100%"
+                                style="background-color: #ffffff; text-align: center; padding: 32px 0 24px; border-bottom: 1px solid #e5eff5;"
+                                align="center">
+                                <table class="feedback-buttons" role="presentation" border="0" cellpadding="0"
+                                    cellspacing="0">
+                                    <tr>
+                                        {{#if feedbackButtons }}
+                                        {{> feedbackButton feedbackButtons href=feedbackButtons.likeHref
+                                        buttonText="いいね"
+                                        iconUrl="https://static.ghost.org/v5.0.0/images/more-like-this-mobile.png"
+                                        width="42" height="42" }}
+                                        {{> feedbackButton feedbackButtons href=feedbackButtons.dislikeHref
+                                        buttonText="イマイチ"
+                                        iconUrl="https://static.ghost.org/v5.0.0/images/less-like-this-mobile.png"
+                                        width="42" height="42" }}
+                                        {{/if}}
+                                        {{#if newsletter.showCommentCta}}
+                                        {{> feedbackButton href=post.commentUrl buttonText='コメントする'
+                                        iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42"
+                                        height="42" }}
+                                        {{/if}}
+                                    </tr>
+                                </table>
+                                <table class="feedback-buttons-mobile" role="presentation" border="0" cellpadding="0"
+                                    cellspacing="0">
+                                    <tr>
+                                        {{#if feedbackButtons }}
+                                        {{> feedbackButtonMobile feedbackButtons href=feedbackButtons.likeHref
+                                        buttonText='いいね'
+                                        iconUrl="https://static.ghost.org/v5.0.0/images/more-like-this-mobile.png"
+                                        width="42" height="42" }}
+                                        {{> feedbackButtonMobile feedbackButtons href=feedbackButtons.dislikeHref
+                                        buttonText='イマイチ'
+                                        iconUrl="https://static.ghost.org/v5.0.0/images/less-like-this-mobile.png"
+                                        width="42" height="42" }}
+                                        {{/if}}
+                                        {{#if newsletter.showCommentCta}}
+                                        {{> feedbackButtonMobile href=post.commentUrl buttonText='コメントをする'
+                                        iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42"
+                                        height="42" }}
+                                        {{/if}}
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                        {{/if}}
+
+                        {{#if latestPosts.length}}
+                        <tr>
+                            <td style="padding: 24px 0; border-bottom: 1px solid #e5eff5;">
+                                <h3 class="latest-posts-header">他の記事</h3>
+                                {{> latestPosts}}
+                            </td>
+                        </tr>
+                        {{/if}}
+
+                        {{#if newsletter.showSubscriptionDetails}}
+                        <tr>
+                            <td class="subscription-box">
+                                <h3>プラン・メール配信設定について</h3>
+                                <p style="margin-bottom: 16px;">
+                                    <span>あなたは<strong>%%{status}%%</strong>に登録しています</span>
+                                </p>
+                                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                    <tr>
+                                        <td class="subscription-details">
+                                            <p class="%%{name_class}%%">名前: %%{name, "未提供"}%%</p>
+                                            <p>メール: <a href="#">%%{email}%%</a></p>
+                                            <p>登録日: %%{created_at}%%</p>
+                                        </td>
+                                        <td align="right" valign="bottom" class="manage-subscription">
+                                            <a href="%%{manage_account_url}%%"> アカウント画面へ &rarr;</a>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+                        {{/if}}
+
+                        <tr>
+                            <td class="wrapper" align="center">
+                                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"
+                                    style="padding-top: 40px; padding-bottom: 30px;">
+                                    <tr>
+                                        <td class="footer">
+                                            <p style="margin: 0 0 4px;">
+                                                Locker Room │ 渡邊雄太公式ファンコミュニティ<br>
+                                                <a href="https://yuta-watanabe.com/"
+                                                    style="color: #3A464C; text-decoration: underline;">
+                                                    https://yuta-watanabe.com/
+                                                </a>
+                                            </p>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td class="footer">
+                                            <p style="margin: 0 0 4px;">
+                                                ※記事投稿の際のメール通知を停止するには
+                                                <a href="%%{manage_account_url}%%"
+                                                    style="color: #3A464C; text-decoration: underline;">
+                                                    プロフィールのメール設定
+                                                </a>
+                                                からオフにしてください。
+                                            </p>
+                                            <p style="margin: 0 0 4px;">
+                                                ※本メールは送信専用アドレスから自動送信されています。本メールにご返信いただきましても、対応いたしかねます。
+                                            </p>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </td>
+                        </tr>
+
+                    </table>
+                    <!-- END CENTERED WHITE CONTAINER -->
+                </div>
+            </td>
+            <td>&nbsp;</td>
+        </tr>
+
+        <!--[if mso]>
+                            </table>
+                        </center>
+                    </td>
+                </tr>
+            <![endif]-->
+    </table>
+</body>
+
+</html>

--- a/partials/email-templates/newsletter.hbs
+++ b/partials/email-templates/newsletter.hbs
@@ -1,319 +1,303 @@
 <!doctype html>
 <html>
-
-<head>
-    <meta name="viewport" content="width=device-width" />
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <!--[if mso]><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch><o:AllowPNG/></o:OfficeDocumentSettings></xml><![endif]-->
-    <title>{{post.title}} 【Locker Room │ 渡邊雄太公式ファンコミュニティ】</title>
-    {{>styles}}
-</head>
-
-<body>
-    <span class="preheader">{{preheader}}</span>
-    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body" width="100%">
-        <!-- Outlook doesn't respect max-width so we need an extra centered table -->
-        <!--[if mso]>
+    <head>
+        <meta name="viewport" content="width=device-width" />
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <!--[if mso]><xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch><o:AllowPNG/></o:OfficeDocumentSettings></xml><![endif]-->
+        <title>{{post.title}} 【Locker Room │ 渡邊雄太公式ファンコミュニティ】</title>
+        {{>styles}}
+    </head>
+    <body>
+        <span class="preheader">{{preheader}}</span>
+        <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="body" width="100%">
+            <!-- Outlook doesn't respect max-width so we need an extra centered table -->
+            <!--[if mso]>
             <tr>
                 <td>
                     <center>
                         <table border="0" cellpadding="0" cellspacing="0" width="600">
             <![endif]-->
-        <tr>
-            <td>&nbsp;</td>
-            <td class="container">
-                <div class="content">
-                    <!-- START CENTERED WHITE CONTAINER -->
-                    <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main" width="100%">
+            <tr>
+                <td>&nbsp;</td>
+                <td class="container">
+                    <div class="content">
+                        <!-- START CENTERED WHITE CONTAINER -->
+                        <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="main" width="100%">
 
-                        <!-- START MAIN CONTENT AREA -->
-                        <tr>
-                            <td class="wrapper">
-                                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
-                                    {{#if headerImage}}
-                                    <tr class="header-image-row">
-                                        <td class="header-image" width="100%" align="center">
-                                            <a href="{{site.url}}">
-                                                <img src="{{headerImage}}" {{#if headerImageWidth}}
-                                                    width="{{headerImageWidth}}" {{/if}}>
-                                            </a>
-                                        </td>
-                                    </tr>
-                                    {{/if}}
-                                    {{#if (or showHeaderIcon showHeaderTitle showHeaderName) }}
-                                    <tr class="site-info-row">
-                                        <td class="site-info" width="100%" align="center">
-                                            <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                                                {{#if (and showHeaderIcon site.iconUrl) }}
-                                                <tr>
-                                                    <td class="site-icon"><a href="{{site.url}}"><img
-                                                                src="{{site.iconUrl}}" alt="{{site.title}}" border="0"
-                                                                width="48" height="48"></a></td>
-                                                </tr>
-                                                {{/if}}
-                                                {{#if showHeaderTitle }}
-                                                <tr>
-                                                    <td
-                                                        class="site-url {{#unless showHeaderName}}site-url-bottom-padding{{/unless}}">
-                                                        <div style="width: 100% !important;"><a href="{{site.url}}"
-                                                                class="site-title">{{site.title}}</a></div>
-                                                    </td>
-                                                </tr>
-                                                {{/if}}
-                                                {{#if (and showHeaderName showHeaderTitle) }}
-                                                <tr>
-                                                    <td class="site-url site-url-bottom-padding">
-                                                        <div style="width: 100% !important;"><a href="{{site.url}}"
-                                                                class="site-subtitle">{{newsletter.name}}</a></div>
-                                                    </td>
-                                                </tr>
-                                                {{/if}}
-                                                {{#if (and showHeaderName (not showHeaderTitle)) }}
-                                                <tr>
-                                                    <td class="site-url site-url-bottom-padding">
-                                                        <div style="width: 100% !important;"><a href="{{site.url}}"
-                                                                class="site-title">{{newsletter.name}}</a></div>
-                                                    </td>
-                                                </tr>
-                                                {{/if}}
+                            <!-- START MAIN CONTENT AREA -->
+                            <tr>
+                                <td class="wrapper">
+                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                        {{!-- ヘッダー画像 --}}
+                                        {{#if headerImage}}
+                                            <tr class="header-image-row">
+                                                <td class="header-image" width="100%" align="center">
+                                                    <a href="{{site.url}}">
+                                                        <img
+                                                            src="{{headerImage}}"
+                                                            {{#if headerImageWidth}}
+                                                                width="{{headerImageWidth}}"
+                                                            {{/if}}
+                                                        >
+                                                    </a>
+                                                </td>
+                                            </tr>
+                                        {{/if}}
 
-                                            </table>
-                                        </td>
-                                    </tr>
-                                    {{/if}}
+                                        {{!-- サイト情報表示（サイトアイコン・サイトタイトルなど） --}}
+                                        {{#if (or showHeaderIcon showHeaderTitle showHeaderName) }}
+                                            <tr class="site-info-row">
+                                                <td class="site-info" width="100%" align="center">
+                                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                                        {{#if (and showHeaderIcon site.iconUrl) }}
+                                                            <tr>
+                                                                <td class="site-icon">
+                                                                    <a href="{{site.url}}">
+                                                                        <img src="{{site.iconUrl}}" alt="{{site.title}}" border="0" width="48" height="48">
+                                                                    </a>
+                                                                </td>
+                                                            </tr>
+                                                        {{/if}}
+                                                        {{#if showHeaderTitle }}
+                                                            <tr>
+                                                                <td class="site-url {{#unless showHeaderName}}site-url-bottom-padding{{/unless}}">
+                                                                    <div style="width: 100% !important;">
+                                                                        <a href="{{site.url}}" class="site-title">{{site.title}}</a>
+                                                                    </div>
+                                                                </td>
+                                                            </tr>
+                                                        {{/if}}
+                                                        {{#if (and showHeaderName showHeaderTitle) }}
+                                                            <tr>
+                                                                <td class="site-url site-url-bottom-padding">
+                                                                    <div style="width: 100% !important;">
+                                                                        <a href="{{site.url}}" class="site-subtitle">{{newsletter.name}}</a>
+                                                                    </div>
+                                                                </td>
+                                                            </tr>
+                                                        {{/if}}
+                                                        {{#if (and showHeaderName (not showHeaderTitle)) }}
+                                                            <tr>
+                                                                <td class="site-url site-url-bottom-padding">
+                                                                    <div style="width: 100% !important;">
+                                                                        <a href="{{site.url}}" class="site-title">{{newsletter.name}}</a>
+                                                                    </div>
+                                                                </td>
+                                                            </tr>
+                                                        {{/if}}
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                        {{/if}}
 
-                                    {{#if newsletter.showPostTitleSection}}
-                                    <tr>
-                                        <td class="{{classes.title}}">
-                                            <a href="{{post.url}}" class="{{classes.titleLink}}">{{post.title}}</a>
-                                        </td>
-                                    </tr>
-                                    {{#if (and newsletter.showExcerpt post.customExcerpt)}}
-                                    <tr>
-                                        <td class="post-excerpt-wrapper" style="width: 100%">
-                                            <p class="{{classes.excerpt}}">{{post.customExcerpt}}</p>
-                                        </td>
-                                    </tr>
-                                    {{/if}}
-                                    <tr>
-                                        <td style="width: 100%">
-                                            <table class="post-meta-wrapper" role="presentation" border="0"
-                                                cellpadding="0" cellspacing="0" width="100%"
-                                                style="padding-bottom: 32px;">
+                                        {{!-- 記事タイトルや抜粋、メタ情報 --}}
+                                        {{#if newsletter.showPostTitleSection}}
+                                            <tr>
+                                                <td class="{{classes.title}}">
+                                                    <a href="{{post.url}}" class="{{classes.titleLink}}">{{post.title}}</a>
+                                                </td>
+                                            </tr>
+                                            {{#if (and newsletter.showExcerpt post.customExcerpt)}}
                                                 <tr>
-                                                    <td height="20" class="{{classes.meta}}" style="padding: 0;">
-                                                        {{post.authors}} • <span
-                                                            class="post-meta-date">{{post.publishedAt}} </span>
-                                                    </td>
-                                                    <td class="{{classes.meta}} view-online desktop">
-                                                        <a href="{{post.url}}" class="view-online-link">ブラウザで見る</a>
+                                                    <td class="post-excerpt-wrapper" style="width: 100%">
+                                                        <p class="{{classes.excerpt}}">{{post.customExcerpt}}</p>
                                                     </td>
                                                 </tr>
-                                                <tr class="{{classes.meta}} view-online-mobile">
-                                                    <td height="20" class="view-online">
-                                                        <a href="{{post.url}}" class="view-online-link">ブラウザで見る</a>
-                                                    </td>
-                                                </tr>
-                                            </table>
-                                        </td>
-                                    </tr>
-                                    {{/if}}
+                                            {{/if}}
+                                            <tr>
+                                                <td style="width: 100%">
+                                                    <table class="post-meta-wrapper" role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="padding-bottom: 32px;">
+                                                        <tr>
+                                                            <td height="20" class="{{classes.meta}}" style="padding: 0;">
+                                                                {{post.authors}} • <span class="post-meta-date">{{post.publishedAt}}</span>
+                                                            </td>
+                                                            <td class="{{classes.meta}} view-online desktop">
+                                                                <a href="{{post.url}}" class="view-online-link">ブラウザで見る</a>
+                                                            </td>
+                                                        </tr>
+                                                        <tr class="{{classes.meta}} view-online-mobile">
+                                                            <td height="20" class="view-online">
+                                                                <a href="{{post.url}}" class="view-online-link">ブラウザで見る</a>
+                                                            </td>
+                                                        </tr>
+                                                    </table>
+                                                </td>
+                                            </tr>
+                                        {{/if}}
 
-                                    {{#if showFeatureImage }}
-                                    <tr class="feature-image-row">
-                                        <td class="feature-image
+                                        {{!-- アイキャッチ画像 --}}
+                                        {{#if showFeatureImage }}
+                                            <tr class="feature-image-row">
+                                                <td class="feature-image
                                                     {{#if post.feature_image_caption }}
                                                         feature-image-with-caption
                                                     {{/if}}
-                                                " align="center"><img src="{{post.feature_image}}" {{#if
-                                                post.feature_image_width }} width="{{post.feature_image_width}}" {{/if}}
-                                                {{#if post.feature_image_alt }} alt="{{post.feature_image_alt}}"
-                                                {{/if}}></td>
-                                    </tr>
-
-                                    {{#if post.feature_image_caption }}
-                                    <tr>
-                                        <td align="center">
-                                            <div class="feature-image-caption">
-                                                {{{post.feature_image_caption}}}
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    {{/if}}
-                                    {{/if}}
-                                    <tr class="post-content-row">
-                                        <td class="{{classes.body}}">
-                                            <!-- POST CONTENT START -->
-                                            {{{html}}}
-                                            <!-- POST CONTENT END -->
-
-                                            {{#if paywall}}
-                                                <div class="align-center" style="text-align: center;">
-                                                    <hr
-                                                        style="position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e5eff5;">
-                                                    <h2
-                                                        style="margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 26px;">
-                                                        <span
-                                                            style="white-space: nowrap; font-size: 20px!important;">続きを読むには、プランのアップグレードが必要です。</span>
-                                                    </h2>
-                                                    <div class="btn btn-accent"
-                                                        style="box-sizing: border-box; width: 100%; display: table;">
-                                                        <table border="0" cellspacing="0" cellpadding="0" align="center"
-                                                            style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
-                                                            <tbody>
-                                                                <tr>
-                                                                    <td align="center" valign="top"
-                                                                        bgcolor="{{accentColor}}"
-                                                                        style="vertical-align: top; text-align: center; border-radius: 5px;">
-                                                                        <a href="{{paywall.signupUrl}}"
-                                                                            style="overflow-wrap: anywhere; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; background-color: {{accentColor}}; border-color: {{accentColor}}; color: #FFFFFF;"
-                                                                            target="_blank">プランのアップグレード</a>
-                                                                    </td>
-                                                                </tr>
-                                                            </tbody>
-                                                        </table>
-                                                    </div>
-                                                    <p style="margin: 0 0 1.5em 0; line-height: 1.6em;"></p>
-                                                </div>
-
+                                                " align="center">
+                                                    <img
+                                                        src="{{post.feature_image}}"
+                                                        {{#if post.feature_image_width }}
+                                                            width="{{post.feature_image_width}}"
+                                                        {{/if}}
+                                                        {{#if post.feature_image_alt }}
+                                                            alt="{{post.feature_image_alt}}"
+                                                        {{/if}}
+                                                    >
+                                                </td>
+                                            </tr>
+                                            {{#if post.feature_image_caption }}
+                                                <tr>
+                                                    <td align="center">
+                                                        <div class="feature-image-caption">
+                                                            {{{post.feature_image_caption}}}
+                                                        </div>
+                                                    </td>
+                                                </tr>
                                             {{/if}}
-                                        </td>
-                                    </tr>
-                                </table>
-                            </td>
-                        </tr>
-
-                        <!-- END MAIN CONTENT AREA -->
-
-                        {{#if (or feedbackButtons newsletter.showCommentCta) }}
-                        <tr>
-                            <td dir="ltr" width="100%"
-                                style="background-color: #ffffff; text-align: center; padding: 32px 0 24px; border-bottom: 1px solid #e5eff5;"
-                                align="center">
-                                <table class="feedback-buttons" role="presentation" border="0" cellpadding="0"
-                                    cellspacing="0">
-                                    <tr>
-                                        {{#if feedbackButtons }}
-                                        {{> feedbackButton feedbackButtons href=feedbackButtons.likeHref
-                                        buttonText="いいね"
-                                        iconUrl="https://static.ghost.org/v5.0.0/images/more-like-this-mobile.png"
-                                        width="42" height="42" }}
-                                        {{> feedbackButton feedbackButtons href=feedbackButtons.dislikeHref
-                                        buttonText="イマイチ"
-                                        iconUrl="https://static.ghost.org/v5.0.0/images/less-like-this-mobile.png"
-                                        width="42" height="42" }}
                                         {{/if}}
-                                        {{#if newsletter.showCommentCta}}
-                                        {{> feedbackButton href=post.commentUrl buttonText='コメントする'
-                                        iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42"
-                                        height="42" }}
+
+                                        {{!-- メイン本文 + 有料ブロック --}}
+                                        <tr class="post-content-row">
+                                            <td class="{{classes.body}}">
+                                                <!-- POST CONTENT START -->
+                                                {{{html}}}
+                                                <!-- POST CONTENT END -->
+
+                                                {{!-- paywall 部分をユーザー独自カスタマイズ --}}
+                                                {{#if paywall}}
+                                                    <div class="align-center" style="text-align: center;">
+                                                        <hr
+                                                            style="position: relative; display: block; width: 100%; margin: 3em 0; padding: 0; height: 1px; border: 0; border-top: 1px solid #e5eff5;">
+                                                        <h2
+                                                            style="margin-top: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; line-height: 1.11em; font-weight: 700; text-rendering: optimizeLegibility; margin: 1.5em 0 0.5em 0; font-size: 26px;">
+                                                            <span style="white-space: nowrap; font-size: 20px!important;">続きを読むには、プランのアップグレードが必要です。</span>
+                                                        </h2>
+                                                        <div class="btn btn-accent" style="box-sizing: border-box; width: 100%; display: table;">
+                                                            <table border="0" cellspacing="0" cellpadding="0" align="center"
+                                                                style="border-collapse: separate; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: auto;">
+                                                                <tbody>
+                                                                    <tr>
+                                                                        <td align="center" valign="top"
+                                                                            bgcolor="{{accentColor}}"
+                                                                            style="vertical-align: top; text-align: center; border-radius: 5px;">
+                                                                            <a href="{{paywall.signupUrl}}"
+                                                                                style="overflow-wrap: anywhere; border: solid 1px #3498db; border-radius: 5px; box-sizing: border-box; cursor: pointer; display: inline-block; font-size: 14px; font-weight: bold; margin: 0; padding: 12px 25px; text-decoration: none; background-color: {{accentColor}}; border-color: {{accentColor}}; color: #FFFFFF;"
+                                                                                target="_blank">プランのアップグレード</a>
+                                                                        </td>
+                                                                    </tr>
+                                                                </tbody>
+                                                            </table>
+                                                        </div>
+                                                        <p style="margin: 0 0 1.5em 0; line-height: 1.6em;"></p>
+                                                    </div>
+                                                {{/if}}
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                            <!-- END MAIN CONTENT AREA -->
+
+                            {{!-- フィードバックボタン・コメント --}}
+                            {{#if (or feedbackButtons newsletter.showCommentCta) }}
+                                <tr>
+                                    <td dir="ltr" width="100%" style="background-color: #ffffff; text-align: center; padding: 32px 0 24px; border-bottom: 1px solid #e5eff5;" align="center">
+                                        <table class="feedback-buttons" role="presentation" border="0" cellpadding="0" cellspacing="0">
+                                            <tr>
+                                                {{#if feedbackButtons }}
+                                                    {{> feedbackButton feedbackButtons href=feedbackButtons.likeHref buttonText="いいね" iconUrl="https://static.ghost.org/v5.0.0/images/more-like-this-mobile.png" width="42" height="42" }}
+                                                    {{> feedbackButton feedbackButtons href=feedbackButtons.dislikeHref buttonText="イマイチ" iconUrl="https://static.ghost.org/v5.0.0/images/less-like-this-mobile.png" width="42" height="42" }}
+                                                {{/if}}
+                                                {{#if newsletter.showCommentCta}}
+                                                    {{> feedbackButton href=post.commentUrl buttonText="コメントする" iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42" height="42"}}
+                                                {{/if}}
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            {{/if}}
+
+                            {{!-- 最新記事一覧 --}}
+                            {{#if latestPosts.length}}
+                                <tr>
+                                    <td style="padding: 24px 0; border-bottom: 1px solid #e5eff5;">
+                                        <h3 class="latest-posts-header">他の記事</h3>
+                                        {{> latestPosts}}
+                                    </td>
+                                </tr>
+                            {{/if}}
+
+                            {{!-- サブスクリプション詳細 --}}
+                            {{#if newsletter.showSubscriptionDetails}}
+                                <tr>
+                                    <td class="subscription-box">
+                                        <h3>プラン・メール配信設定について</h3>
+                                        <p style="margin-bottom: 16px;">
+                                            <span>あなたは<strong>%%{status}%%</strong>に登録しています</span>
+                                        </p>
+                                        <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+                                            <tr>
+                                                <td class="subscription-details">
+                                                    <p class="%%{name_class}%%">名前: %%{name, "未提供"}%%</p>
+                                                    <p>メール: <a href="#">%%{email}%%</a></p>
+                                                    <p>登録日: %%{created_at}%%</p>
+                                                </td>
+                                                <td align="right" valign="bottom" class="manage-subscription">
+                                                    <a href="%%{manage_account_url}%%"> アカウント画面へ &rarr;</a>
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            {{/if}}
+
+                            {{!-- フッター部分 --}}
+                            <tr>
+                                <td class="wrapper" align="center">
+                                    <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="padding-top: 40px; padding-bottom: 30px;">
+                                        {{!-- もし「footerContent」を使ってカスタム文言を出したい場合は挿入（必要なければ削除） --}}
+                                        {{#if footerContent }}
+                                            <tr><td class="footer">{{{footerContent}}}</td></tr>
                                         {{/if}}
-                                    </tr>
-                                </table>
-                                <table class="feedback-buttons-mobile" role="presentation" border="0" cellpadding="0"
-                                    cellspacing="0">
-                                    <tr>
-                                        {{#if feedbackButtons }}
-                                        {{> feedbackButtonMobile feedbackButtons href=feedbackButtons.likeHref
-                                        buttonText='いいね'
-                                        iconUrl="https://static.ghost.org/v5.0.0/images/more-like-this-mobile.png"
-                                        width="42" height="42" }}
-                                        {{> feedbackButtonMobile feedbackButtons href=feedbackButtons.dislikeHref
-                                        buttonText='イマイチ'
-                                        iconUrl="https://static.ghost.org/v5.0.0/images/less-like-this-mobile.png"
-                                        width="42" height="42" }}
-                                        {{/if}}
-                                        {{#if newsletter.showCommentCta}}
-                                        {{> feedbackButtonMobile href=post.commentUrl buttonText='コメントをする'
-                                        iconUrl="https://static.ghost.org/v5.0.0/images/comment-mobile.png" width="42"
-                                        height="42" }}
-                                        {{/if}}
-                                    </tr>
-                                </table>
-                            </td>
-                        </tr>
-                        {{/if}}
+                                        <tr>
+                                            <td class="footer">
+                                                <p style="margin: 0 0 4px;">
+                                                    Locker Room │ 渡邊雄太公式ファンコミュニティ<br>
+                                                    <a href="https://yuta-watanabe.com/" style="color: #3A464C; text-decoration: underline;">
+                                                        https://yuta-watanabe.com/
+                                                    </a>
+                                                </p>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="footer">
+                                                <p style="margin: 0 0 4px;">
+                                                    ※記事投稿の際のメール通知を停止するには
+                                                    <a href="%%{manage_account_url}%%" style="color: #3A464C; text-decoration: underline;">
+                                                        プロフィールのメール設定
+                                                    </a>
+                                                    からオフにしてください。
+                                                </p>
+                                                <p style="margin: 0 0 4px;">
+                                                    ※本メールは送信専用アドレスから自動送信されています。本メールにご返信いただきましても、対応いたしかねます。
+                                                </p>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
 
-                        {{#if latestPosts.length}}
-                        <tr>
-                            <td style="padding: 24px 0; border-bottom: 1px solid #e5eff5;">
-                                <h3 class="latest-posts-header">他の記事</h3>
-                                {{> latestPosts}}
-                            </td>
-                        </tr>
-                        {{/if}}
-
-                        {{#if newsletter.showSubscriptionDetails}}
-                        <tr>
-                            <td class="subscription-box">
-                                <h3>プラン・メール配信設定について</h3>
-                                <p style="margin-bottom: 16px;">
-                                    <span>あなたは<strong>%%{status}%%</strong>に登録しています</span>
-                                </p>
-                                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
-                                    <tr>
-                                        <td class="subscription-details">
-                                            <p class="%%{name_class}%%">名前: %%{name, "未提供"}%%</p>
-                                            <p>メール: <a href="#">%%{email}%%</a></p>
-                                            <p>登録日: %%{created_at}%%</p>
-                                        </td>
-                                        <td align="right" valign="bottom" class="manage-subscription">
-                                            <a href="%%{manage_account_url}%%"> アカウント画面へ &rarr;</a>
-                                        </td>
-                                    </tr>
-                                </table>
-                            </td>
-                        </tr>
-                        {{/if}}
-
-                        <tr>
-                            <td class="wrapper" align="center">
-                                <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%"
-                                    style="padding-top: 40px; padding-bottom: 30px;">
-                                    <tr>
-                                        <td class="footer">
-                                            <p style="margin: 0 0 4px;">
-                                                Locker Room │ 渡邊雄太公式ファンコミュニティ<br>
-                                                <a href="https://yuta-watanabe.com/"
-                                                    style="color: #3A464C; text-decoration: underline;">
-                                                    https://yuta-watanabe.com/
-                                                </a>
-                                            </p>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td class="footer">
-                                            <p style="margin: 0 0 4px;">
-                                                ※記事投稿の際のメール通知を停止するには
-                                                <a href="%%{manage_account_url}%%"
-                                                    style="color: #3A464C; text-decoration: underline;">
-                                                    プロフィールのメール設定
-                                                </a>
-                                                からオフにしてください。
-                                            </p>
-                                            <p style="margin: 0 0 4px;">
-                                                ※本メールは送信専用アドレスから自動送信されています。本メールにご返信いただきましても、対応いたしかねます。
-                                            </p>
-                                        </td>
-                                    </tr>
-                                </table>
-                            </td>
-                        </tr>
-
-                    </table>
-                    <!-- END CENTERED WHITE CONTAINER -->
-                </div>
-            </td>
-            <td>&nbsp;</td>
-        </tr>
-
-        <!--[if mso]>
+                        </table>
+                        <!-- END CENTERED WHITE CONTAINER -->
+                    </div>
+                </td>
+                <td>&nbsp;</td>
+            </tr>
+            <!--[if mso]>
                             </table>
                         </center>
                     </td>
                 </tr>
             <![endif]-->
-    </table>
-</body>
-
+        </table>
+    </body>
 </html>

--- a/partials/email-templates/report.hbs
+++ b/partials/email-templates/report.hbs
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- 件名を日本語に変更 -->
+    <title>【Locker Room │ 渡邊雄太公式ファンコミュニティ】コメント報告のお知らせ</title>
+    <style>
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+      table[class=body] ul,
+      table[class=body] ol,
+      table[class=body] td,
+      table[class=body] span,
+      table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+      table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+      table[class=body] p[class=small],
+      table[class=body] a[class=small] {
+        font-size: 11px !important;
+      }
+    }
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+      .recipient-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+    }
+    hr {
+      border-width: 0;
+      height: 0;
+      margin-top: 34px;
+      margin-bottom: 34px;
+      border-bottom-width: 1px;
+      border-bottom-color: #EEF5F8;
+    }
+    a {
+      color: #15212A;
+    }
+    </style>
+  </head>
+  <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="width: 100%;">
+      <tr>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-size: 14px; vertical-align: top; display: block; margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
+          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED CONTAINER -->
+            <!-- プレヘッダー（非表示用） 不要であれば削除可能 -->
+            <span class="preheader" style="display: none; visibility: hidden; opacity: 0; overflow: hidden;">
+              {{reporterName}} ({{reporterEmail}}) がコメントを報告しました
+            </span>
+            <table class="main" style="width: 100%; background: #ffffff; border-radius: 8px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
+                    <tr>
+                      <td style="font-size: 14px; vertical-align: top;">
+
+                        <!-- ここから本文 -->
+                        <p style="font-size: 16px; color: #3A464C; margin: 0; margin-bottom: 24px; line-height: 1.8;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティです。<br><br>
+                          {{reporter}} が、「{{postTitle}}」の以下のコメントについて報告しています。このコメントは、あなたが削除するまで表示され続けます。削除は投稿ページから直接行うことができます。
+                        </p>
+
+                        <!-- コメントの概要 -->
+                        <table width="100" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary"
+                               style="width: 100%; min-width: 100%; background: #F9F9FA; border-radius: 7px;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding: 16px;">
+                                <table border="0" cellpadding="0" cellspacing="0">
+                                  <tr>
+                                    <!-- コメント投稿者アイコン -->
+                                    <td style="padding-right: 8px;">
+                                      <div style="width: 44px; height: 44px; background-color: #15171A; border-radius: 999px; font-size: 16px; color: #FFFFFF; text-align: center; font-weight: 500; line-height: 42px;">
+                                        {{memberInitials}}
+                                      </div>
+                                    </td>
+                                    <!-- コメント投稿者名・日時など -->
+                                    <td style="padding-right: 8px;">
+                                      <p style="font-size: 16px; margin: 0; color: #15171A; font-weight: 600;">
+                                        {{memberName}}
+                                      </p>
+                                      <p style="font-size: 13px; margin: 0; color: #95A1AD;">
+                                        {{#if memberExpertise}}{{memberExpertise}} &#8226; {{/if}}{{commentDate}}
+                                      </p>
+                                    </td>
+                                  </tr>
+                                </table>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td align="left" style="font-size: 16px; color: #15171A; vertical-align: top; padding: 0 16px 16px 16px;">
+                                {{{commentHtml}}}
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <!-- ボタン：「コメントを見る」 -->
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" 
+                               style="width: 100%; box-sizing: border-box;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding-top: 32px; padding-bottom: 12px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <!-- ボタンの色をaccentColorと連動。変更可 -->
+                                      <td style="background-color: {{accentColor}}; border-radius: 5px; text-align: center;">
+                                        <a href="{{postUrl}}#ghost-comments"
+                                          target="_blank"
+                                          style="display: inline-block; color: #ffffff; background-color: {{accentColor}}; border: solid 1px {{accentColor}}; border-radius: 5px; text-decoration: none; font-size: 16px; margin: 0; padding: 9px 22px;">
+                                          コメントを見る
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <hr style="margin-top: 32px; margin-bottom: 24px; border-bottom: 1px solid #EEF5F8; border-width: 0;">
+
+                        <!-- URLコピー案内 -->
+                        <p style="font-size: 15px; margin: 0; color: #3A464C; line-height: 1.8; margin-bottom: 8px;">
+                          以下のURLをブラウザにコピー＆ペーストいただくことでも確認が可能です。<br>
+                          <a href="{{postUrl}}#ghost-comments" style="text-decoration: underline; color: #3A464C;">{{postUrl}}#ghost-comments</a>
+                        </p>
+
+                        <!-- 通知オフ案内 -->
+                        <p style="font-size: 14px; margin: 0; margin-top: 24px; line-height: 1.8; color: #3A464C;">
+                          ※コメントの返信の際のメール通知を停止するには、
+                          <a href="{{profileUrl}}" style="text-decoration: underline; color: #3A464C;">
+                            プロフィールのメール設定
+                          </a>
+                          からオフにしてください。
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <!-- フッター -->
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 4px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティ
+                        </p>
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 24px;">
+                          <a href="https://yuta-watanabe.com/" style="text-decoration: underline; color: #3A464C;">
+                            https://yuta-watanabe.com/
+                          </a>
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0;">
+                          ※本メールは送信専用アドレスから自動送信されています。<br>
+                          本メールにご返信いただきましても、対応いたしかねます。
+                        </p>
+                        <!-- ここまで本文 -->
+
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <!-- END MAIN CONTENT AREA -->
+            </table>
+            <!-- END CENTERED CONTAINER -->
+          </div>
+        </td>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/partials/email-templates/signin.js
+++ b/partials/email-templates/signin.js
@@ -1,0 +1,207 @@
+/**
+ * Generates an HTML email template for a login link.
+ *
+ * @param {Function} t - The template function.
+ * @param {string} siteTitle - The title of the site.
+ * @param {string} email - The email address of the recipient.
+ * @param {string} url - The login URL.
+ * @param {string} [accentColor='#15212A'] - The accent color for the email template.
+ * @param {string} siteDomain - The domain of the site.
+ * @param {string} siteUrl - The URL of the site.
+ * @returns {string} The generated HTML email template.
+ */
+module.exports = ({url, accentColor = '#15212A'}) => `
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>ログインリンクのご案内【Locker Room │ 渡邊雄太公式ファンコミュニティ】</title>
+    <style>
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+      table[class=body] ul,
+      table[class=body] ol,
+      table[class=body] td,
+      table[class=body] span,
+      table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+      table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+      table[class=body] p[class=small],
+      table[class=body] a[class=small] {
+        font-size: 11px !important;
+      }
+    }
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+      .recipient-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+    }
+    hr {
+      border-width: 0;
+      height: 0;
+      margin-top: 34px;
+      margin-bottom: 34px;
+      border-bottom-width: 1px;
+      border-bottom-color: #EEF5F8;
+    }
+    a {
+      color: #3A464C;
+    }
+    </style>
+  </head>
+  <body style="background-color: #ffffff; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; width: 100%;">
+      <tr>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="display: block; Margin: 0 auto; max-width: 540px; padding: 10px; width: 540px; font-size: 14px; vertical-align: top;">
+          <div class="content" style="box-sizing: border-box; display: block; Margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED CONTAINER -->
+            <!-- プレヘッダーなどを使用しない場合は以下は削除してもOK -->
+            <span class="preheader" style="color: transparent; display: none; height: 0; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; visibility: hidden; width: 0;">
+              ログインリンクのご案内
+            </span>
+
+            <table class="main" style="border-collapse: separate; width: 100%; background: #ffffff; border-radius: 8px;">
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
+                    <tr>
+                      <td style="font-size: 14px; vertical-align: top;">
+
+                        <!-- 本文ここから -->
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティにログインするには、下記URLをクリックしてください。
+                        </p>
+
+                        <!-- ボタン -->
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="width: 100%;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding-bottom: 35px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <!-- ボタンの色を変更したい場合は background-color や border-color を変更してください -->
+                                      <td style="background-color: ${accentColor}; border-radius: 5px; text-align: center;">
+                                        <a href=${url} target="_blank"
+                                          style="display: inline-block; color: #ffffff; background-color:${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; margin: 0; padding: 9px 22px; font-weight: normal;">
+                                          ログインはこちら
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 16px;">
+                          以下のURLをブラウザにコピー＆ペーストいただくことでもログインが可能です。<br>
+                          ${url}
+                        </p>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 16px;">
+                          ※ログイン用URLの有効期限は24時間です。24時間を過ぎた場合は、もう一度初めからログインの手続きをおこなってください。
+                        </p>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          ※このメールはご入力されたメールアドレスへ自動送信しております。お心当たりがない場合は本メールを削除してください。
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 4px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティ
+                        </p>
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          <a href="https://yuta-watanabe.com/" style="color: #3A464C; text-decoration: underline;">https://yuta-watanabe.com/</a>
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0;">
+                          ※本メールは送信専用アドレスから自動送信されています。本メールにご返信いただきましても、対応いたしかねます。
+                        </p>
+                        <!-- 本文ここまで -->
+                      </td>
+                    </tr>
+                    <!-- END FOOTER -->
+                  </table>
+                </td>
+              </tr>
+              <!-- END MAIN CONTENT AREA -->
+            </table>
+            <!-- END CENTERED CONTAINER -->
+          </div>
+        </td>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>
+`;

--- a/partials/email-templates/signup-paid.js
+++ b/partials/email-templates/signup-paid.js
@@ -1,0 +1,212 @@
+/**
+ * Generates an HTML email template for a paid signup link.
+ *
+ * @param {Function} t - The template function.
+ * @param {string} siteTitle - The title of the site.
+ * @param {string} email - The email address of the recipient.
+ * @param {string} url - The signup URL.
+ * @param {string} [accentColor='#15212A'] - The accent color for the email template.
+ * @param {string} siteDomain - The domain of the site.
+ * @param {string} siteUrl - The URL of the site.
+ * @returns {string} The generated HTML email template.
+ */
+module.exports = ({url, accentColor = '#15212A'}) => `
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- 件名を日本語に変更する例 -->
+    <title>入部完了のご案内【Locker Room │ 渡邊雄太公式ファンコミュニティ】</title>
+    <style>
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+      table[class=body] ul,
+      table[class=body] ol,
+      table[class=body] td,
+      table[class=body] span,
+      table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+      table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+      table[class=body] p[class=small],
+      table[class=body] a[class=small] {
+        font-size: 11px !important;
+      }
+    }
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+      .recipient-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+    }
+    hr {
+      border-width: 0;
+      height: 0;
+      margin-top: 34px;
+      margin-bottom: 34px;
+      border-bottom-width: 1px;
+      border-bottom-color: #EEF5F8;
+    }
+    a {
+      color: #3A464C;
+    }
+    </style>
+  </head>
+  <body style="background-color: #FFFFFF; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; width: 100%; background-color: #FFFFFF;">
+      <tr>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-size: 14px; vertical-align: top; display: block; margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
+          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <!-- 不要ならこのプレヘッダ部分は削除 -->
+            <span class="preheader" style="color: transparent; display: none; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; visibility: hidden;">
+              ログインのご案内
+            </span>
+            <table class="main" style="border-collapse: separate; width: 100%; background: #ffffff; border-radius: 8px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
+                    <tr>
+                      <td style="font-size: 14px; vertical-align: top;">
+
+                        <!-- ここから本文の差し替え -->
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティに入部（登録）いただき、ありがとうございます。<br>
+                          現時点ではお手続きは完了しておりませんので、下記URLをクリックいただきサブスクリプション登録を完了させてください。
+                        </p>
+
+                        <!-- ボタン -->
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="width: 100%;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding-bottom: 35px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <!-- ボタンの色などを必要に応じて調整 -->
+                                      <td style="background-color: ${accentColor}; border-radius: 5px; text-align: center;">
+                                        <a href="${url}" target="_blank"
+                                          style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; margin: 0; padding: 9px 22px; font-weight: normal;">
+                                          入部（登録）はこちら
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <!-- コピー＆ペースト用URLのご案内 -->
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 16px;">
+                          以下のURLをブラウザにコピー＆ペーストいただくことでも入部（登録）が可能です。<br>
+                          ${url}
+                        </p>
+
+                        <!-- 有効期限 -->
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          ※入部（登録）用URLの有効期限は24時間です。<br>
+                          24時間を過ぎた場合は、もう一度初めから入部（登録）の手続きをおこなってください。
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <!-- 運営元情報 -->
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 4px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティ
+                        </p>
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 24px;">
+                          <a href="https://yuta-watanabe.com/" style="color: #3A464C; text-decoration: underline;">
+                            https://yuta-watanabe.com/
+                          </a>
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0;">
+                          ※本メールは送信専用アドレスから自動送信されています。本メールにご返信いただきましても、対応いたしかねます。
+                        </p>
+                        <!-- ここまで本文の差し替え -->
+
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <!-- END MAIN CONTENT AREA -->
+            </table>
+
+          <!-- END CENTERED WHITE CONTAINER -->
+          </div>
+        </td>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>
+`;

--- a/partials/email-templates/signup.js
+++ b/partials/email-templates/signup.js
@@ -1,0 +1,216 @@
+/**
+ * Generates an HTML email template for a signup link.
+ *
+ * @param {Function} t - The template function.
+ * @param {string} siteTitle - The title of the site.
+ * @param {string} email - The email address of the recipient.
+ * @param {string} url - The signup URL.
+ * @param {string} [accentColor='#15212A'] - The accent color for the email template.
+ * @param {string} siteDomain - The domain of the site.
+ * @param {string} siteUrl - The URL of the site.
+ * @returns {string} The generated HTML email template.
+ */
+
+module.exports = ({url, accentColor = '#15212A'}) => `
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- 件名を日本語に変更 -->
+    <title>入部のご案内【Locker Room │ 渡邊雄太公式ファンコミュニティ】</title>
+    <style>
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+      table[class=body] ul,
+      table[class=body] ol,
+      table[class=body] td,
+      table[class=body] span,
+      table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+      table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+      table[class=body] p[class=small],
+      table[class=body] a[class=small] {
+        font-size: 11px !important;
+      }
+    }
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+      .recipient-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+    }
+    hr {
+      border-width: 0;
+      height: 0;
+      margin-top: 34px;
+      margin-bottom: 34px;
+      border-bottom-width: 1px;
+      border-bottom-color: #EEF5F8;
+    }
+    a {
+      color: #3A464C;
+    }
+    </style>
+  </head>
+  <body style="background-color: #FFFFFF; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5em; margin: 0; padding: 0;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; width: 100%; background-color: #FFFFFF;">
+      <tr>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-size: 14px; vertical-align: top; display: block; margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
+          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <!-- プレヘッダ(非表示テキスト)は不要であれば削除可能です -->
+            <span class="preheader" style="display: none; max-height: 0; max-width: 0; opacity: 0; overflow: hidden; visibility: hidden;">
+              入部（登録）のご案内
+            </span>
+            <table class="main" style="border-collapse: separate; width: 100%; background: #ffffff; border-radius: 8px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
+                    <tr>
+                      <td style="font-size: 14px; vertical-align: top;">
+
+                        <!-- ここから本文を差し替え -->
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティに入部（登録）いただき、ありがとうございます。<br>
+                          現時点ではお手続きは完了しておりませんので、下記URLをクリックいただき入部（登録）を完了させてください。
+                        </p>
+
+                        <!-- ボタン部分 -->
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="width: 100%;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding-bottom: 35px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <!-- ボタンの色を変更したい場合は background-color や border-color をaccentColor以外に変更してください -->
+                                      <td style="background-color: ${accentColor}; border-radius: 5px; text-align: center;">
+                                        <a href="${url}" target="_blank"
+                                          style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; margin: 0; padding: 9px 22px; font-weight: normal;">
+                                          入部（登録）はこちら
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 16px;">
+                          以下のURLをブラウザにコピー＆ペーストいただくことでも入部（登録）が可能です。<br>
+                          ${url}
+                        </p>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          ※入部（登録）用URLの有効期限は24時間です。24時間以内に入部（登録）手続きが行われない場合には、もう一度初めから入部（登録）の手続きをおこなってください。
+                        </p>
+
+                        <!-- 注意書き/自動送信メール -->
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          ※このメールはご入力されたメールアドレスへ自動送信しております。お心当たりがない場合は本メールを削除してください。
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <!-- 運営元情報 -->
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 4px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティ
+                        </p>
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 24px;">
+                          <a href="https://yuta-watanabe.com/" style="color: #3A464C; text-decoration: underline;">
+                            https://yuta-watanabe.com/
+                          </a>
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0;">
+                          ※本メールは送信専用アドレスから自動送信されています。本メールにご返信いただきましても、対応いたしかねます。
+                        </p>
+                        <!-- ここまで本文の差し替え -->
+
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <!-- END MAIN CONTENT AREA -->
+            <!-- END MAIN CONTENT AREA -->
+            </table>
+
+          <!-- END CENTERED WHITE CONTAINER -->
+          </div>
+        </td>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>
+`;

--- a/partials/email-templates/subjects.js
+++ b/partials/email-templates/subjects.js
@@ -1,0 +1,71 @@
+const signin = () => {
+    return 'ログインリンクのご案内【Locker Room │ 渡邊雄太公式ファンコミュニティ】';
+};
+
+const subscribe = () => {
+    return 'サブスクリプション登録の確認【Locker Room │ 渡邊雄太公式ファンコミュニティ】';
+};
+
+const signup = () => {
+    return '入部（登録）のご案内【Locker Room │ 渡邊雄太公式ファンコミュニティ】';
+};
+
+const signupPaid = () => {
+    return '入部（登録）いただきありがとうございます【Locker Room │ 渡邊雄太公式ファンコミュニティ】';
+};
+
+const updateEmail = () => {
+    return 'メールアドレスを確認してください【Locker Room │ 渡邊雄太公式ファンコミュニティ】';
+};
+
+/**
+ * Generates a subject for a new comment email.
+ *
+ * @param {string} postTitle - The title of the post.
+ * @returns {string} The subject for the new comment email.
+ */
+const newComment = ({postTitle}) => {
+    return `${postTitle}に新しいコメントがありました【Locker Room │ 渡邊雄太公式ファンコミュニティ】`;
+};
+
+/**
+ * Generates a subject for a new comment reply email.
+ *
+ * @param {string} postTitle - The title of the post.
+ * @returns {string} The subject for the new comment reply email.
+ */
+const newCommentReply = ({postTitle}) => {
+    return `「${postTitle}」に返信コメントがつきました【Locker Room │ 渡邊雄太公式ファンコミュニティ】`;
+};
+
+/**
+ * Generates a subject for a report email.
+ *
+ * @param {string} postTitle - The title of the post.
+ * @returns {string} The subject for the report email.
+ */
+const report = ({postTitle}) => {
+    return `「${postTitle}」に関する報告【Locker Room │ 渡邊雄太公式ファンコミュニティ】`;
+};
+
+/**
+ * Generates a subject for a newsletter email.
+ *
+ * @param {string} postTitle - The title of the post.
+ * @returns {string} The subject for the newsletter email.
+ */
+const newsletter = ({postTitle}) => {
+    return `${postTitle} 【Locker Room │ 渡邊雄太公式ファンコミュニティ】`;
+};
+
+module.exports = {
+    signin,
+    subscribe,
+    signup,
+    signupPaid,
+    updateEmail,
+    newComment,
+    newCommentReply,
+    report,
+    newsletter
+};

--- a/partials/email-templates/subscribe.js
+++ b/partials/email-templates/subscribe.js
@@ -1,0 +1,215 @@
+/**
+ * Generates an HTML email template for a subscribe link.
+ *
+ * @param {Function} t - The template function.
+ * @param {string} siteTitle - The title of the site.
+ * @param {string} email - The email address of the recipient.
+ * @param {string} url - The subscribe URL.
+ * @param {string} [accentColor='#15212A'] - The accent color for the email template.
+ * @param {string} siteDomain - The domain of the site.
+ * @param {string} siteUrl - The URL of the site.
+ * @returns {string} The generated HTML email template.
+ */
+
+module.exports = ({url, accentColor = '#15212A'}) => `
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- 件名を日本語に変更 -->
+    <title>メールアドレスご確認のご案内【Locker Room │ 渡邊雄太公式ファンコミュニティ】</title>
+    <style>
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+      table[class=body] ul,
+      table[class=body] ol,
+      table[class=body] td,
+      table[class=body] span,
+      table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+      table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+      table[class=body] p[class=small],
+      table[class=body] a[class=small] {
+        font-size: 11px !important;
+      }
+    }
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+      .recipient-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+    }
+    hr {
+      border-width: 0;
+      height: 0;
+      margin-top: 34px;
+      margin-bottom: 34px;
+      border-bottom-width: 1px;
+      border-bottom-color: #EEF5F8;
+    }
+    a {
+      color: #3A464C;
+    }
+    </style>
+  </head>
+  <body style="background-color: #FFFFFF; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="border-collapse: separate; width: 100%; background-color: #FFFFFF;">
+      <tr>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="font-size: 14px; vertical-align: top; display: block; margin: 0 auto; max-width: 540px; padding: 10px; width: 540px;">
+          <div class="content" style="box-sizing: border-box; display: block; margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <!-- プレヘッダー（非表示テキスト） 不要であれば削除可能 -->
+            <span class="preheader" style="display: none; max-height: 0; max-width: 0; opacity: 0; overflow: hidden;">
+              メールアドレスのご確認について
+            </span>
+
+            <table class="main" style="border-collapse: separate; width: 100%; background: #ffffff; border-radius: 8px;">
+
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
+                    <tr>
+                      <td style="font-size: 14px; vertical-align: top;">
+
+                        <!-- ここから本文を差し替え -->
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティです。<br><br>
+                          入部（登録）を完了させるために、下記URLをクリックいただき<br>
+                          メールアドレスの確認を完了させてください。
+                        </p>
+
+                        <!-- ボタン部分 -->
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="width: 100%;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding-bottom: 35px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <!-- ボタンの色は accentColor を使用。変更したい場合は適宜修正 -->
+                                      <td style="background-color: ${accentColor}; border-radius: 5px; text-align: center;">
+                                        <a href="${url}" target="_blank"
+                                          style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; margin: 0; padding: 9px 22px; font-weight: normal;">
+                                          メールアドレスを確認する
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 16px;">
+                          以下のURLをブラウザにコピー＆ペーストいただくことでも確認が可能です。<br>
+                          ${url}
+                        </p>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          ※確認用URLの有効期限は24時間です。24時間以内に確認が行われない場合には、もう一度初めから手続きをおこなってください。
+                        </p>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          ※このメールはご入力されたメールアドレスへ自動送信しております。お心当たりがない場合は本メールを削除してください。
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <!-- 運営元情報 -->
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 4px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティ
+                        </p>
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 24px;">
+                          <a href="https://yuta-watanabe.com/" style="color: #3A464C; text-decoration: underline;">
+                            https://yuta-watanabe.com/
+                          </a>
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0;">
+                          ※本メールは送信専用アドレスから自動送信されています。本メールにご返信いただきましても、対応いたしかねます。
+                        </p>
+                        <!-- ここまで本文の差し替え -->
+
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <!-- END MAIN CONTENT AREA -->
+            </table>
+            <!-- END CENTERED WHITE CONTAINER -->
+          </div>
+        </td>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>
+`;

--- a/partials/email-templates/update-email.js
+++ b/partials/email-templates/update-email.js
@@ -1,0 +1,200 @@
+/**
+ * Generates an HTML email template for a update email link.
+ *
+ * @param {Function} t - The template function.
+ * @param {string} siteTitle - The title of the site.
+ * @param {string} email - The email address of the recipient.
+ * @param {string} url - The update email URL.
+ * @param {string} [accentColor='#15212A'] - The accent color for the email template.
+ * @param {string} siteDomain - The domain of the site.
+ * @param {string} siteUrl - The URL of the site.
+ * @returns {string} The generated HTML email template.
+ */
+
+module.exports = ({url, accentColor = '#15212A'}) => `
+<!doctype html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- 件名を日本語に変更 -->
+    <title>メールアドレスご確認のご案内【Locker Room │ 渡邊雄太公式ファンコミュニティ】</title>
+    <style>
+    /* -------------------------------------
+        RESPONSIVE AND MOBILE FRIENDLY STYLES
+    ------------------------------------- */
+    @media only screen and (max-width: 620px) {
+      table[class=body] h1 {
+        font-size: 28px !important;
+        margin-bottom: 10px !important;
+      }
+      table[class=body] p,
+      table[class=body] ul,
+      table[class=body] ol,
+      table[class=body] td,
+      table[class=body] span,
+      table[class=body] a {
+        font-size: 16px !important;
+      }
+      table[class=body] .wrapper,
+      table[class=body] .article {
+        padding: 10px !important;
+      }
+      table[class=body] .content {
+        padding: 0 !important;
+      }
+      table[class=body] .container {
+        padding: 0 !important;
+        width: 100% !important;
+      }
+      table[class=body] .main {
+        border-left-width: 0 !important;
+        border-radius: 0 !important;
+        border-right-width: 0 !important;
+      }
+      table[class=body] .btn table {
+        width: 100% !important;
+      }
+      table[class=body] .btn a {
+        width: 100% !important;
+      }
+      table[class=body] .img-responsive {
+        height: auto !important;
+        max-width: 100% !important;
+        width: auto !important;
+      }
+    }
+    /* -------------------------------------
+        PRESERVE THESE STYLES IN THE HEAD
+    ------------------------------------- */
+    @media all {
+      .ExternalClass {
+        width: 100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+        line-height: 100%;
+      }
+      .recipient-link a {
+        color: inherit !important;
+        font-family: inherit !important;
+        font-size: inherit !important;
+        font-weight: inherit !important;
+        line-height: inherit !important;
+        text-decoration: none !important;
+      }
+      #MessageViewBody a {
+        color: inherit;
+        text-decoration: none;
+        font-size: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        line-height: inherit;
+      }
+    }
+    hr {
+      border-width: 0;
+      height: 0;
+      margin-top: 34px;
+      margin-bottom: 34px;
+      border-bottom-width: 1px;
+      border-bottom-color: #EEF5F8;
+    }
+    </style>
+  </head>
+  <body style="background-color: #F4F8FB; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.4; margin: 0; padding: 0;">
+    <table border="0" cellpadding="0" cellspacing="0" class="body" style="width: 100%; background-color: #F4F8FB;">
+      <tr>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+        <td class="container" style="display: block; margin: 0 auto; max-width: 600px; padding: 10px; width: 600px; font-size: 14px; vertical-align: top;">
+          <div class="content" style="box-sizing: border-box; margin: 0 auto; max-width: 600px; padding: 30px 20px;">
+
+            <!-- START CENTERED WHITE CONTAINER -->
+            <table class="main" style="border-collapse: separate; width: 100%; background: #ffffff; border-radius: 8px;">
+              <!-- START MAIN CONTENT AREA -->
+              <tr>
+                <td class="wrapper" style="padding: 40px 50px; font-size: 14px; vertical-align: top; box-sizing: border-box;">
+                  <table border="0" cellpadding="0" cellspacing="0" style="width: 100%;">
+                    <tr>
+                      <td style="font-size: 14px; vertical-align: top;">
+
+                        <!-- ここから本文を置き換え -->
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティです。<br><br>
+                          下記URLをクリックいただきメールアドレスの確認を完了させてください。
+                        </p>
+
+                        <!-- ボタン部分 -->
+                        <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary" style="width: 100%;">
+                          <tbody>
+                            <tr>
+                              <td align="left" style="padding-bottom: 35px;">
+                                <table border="0" cellpadding="0" cellspacing="0" style="width: auto;">
+                                  <tbody>
+                                    <tr>
+                                      <td style="background-color: ${accentColor} border-radius: 5px; text-align: center;">
+                                        <a href="${url}"
+                                          target="_blank"
+                                          style="display: inline-block; color: #ffffff; background-color: ${accentColor}; border: solid 1px ${accentColor}; border-radius: 5px; box-sizing: border-box; cursor: pointer; text-decoration: none; font-size: 16px; margin: 0; padding: 9px 22px;">
+                                          メールアドレスを確認する
+                                        </a>
+                                      </td>
+                                    </tr>
+                                  </tbody>
+                                </table>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 16px;">
+                          以下のURLをブラウザにコピー＆ペーストいただくことでも確認が可能です。<br>
+                          ${url}
+                        </p>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          ※確認用URLの有効期限は24時間です。24時間以内に確認が行われない場合には、もう一度初めから手続きをおこなってください。
+                        </p>
+
+                        <p style="font-size: 16px; color: #3A464C; line-height: 1.8; margin: 0; margin-bottom: 24px;">
+                          ※このメールはご入力されたメールアドレスへ自動送信しております。お心当たりがない場合は本メールを削除してください。
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 4px;">
+                          Locker Room │ 渡邊雄太公式ファンコミュニティ
+                        </p>
+                        <p style="font-size: 14px; color: #3A464C; margin: 0; margin-bottom: 24px;">
+                          <a href="https://yuta-watanabe.com/" style="text-decoration: underline; color: #3A464C;">
+                            https://yuta-watanabe.com/
+                          </a>
+                        </p>
+
+                        <hr style="border-width: 0; margin: 24px 0; border-bottom: 1px solid #EEF5F8;">
+
+                        <p style="font-size: 14px; color: #3A464C; line-height: 1.8; margin: 0;">
+                          ※本メールは送信専用アドレスから自動送信されています。本メールにご返信いただきましても、対応いたしかねます。
+                        </p>
+                        <!-- ここまで本文を置き換え -->
+
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+              <!-- END MAIN CONTENT AREA -->
+            </table>
+          <!-- END CENTERED WHITE CONTAINER -->
+          </div>
+        </td>
+        <td style="font-size: 14px; vertical-align: top;">&nbsp;</td>
+      </tr>
+    </table>
+  </body>
+</html>
+`;


### PR DESCRIPTION
## Notionタスク
[テンプレートの上書き（オーバーライド）機能の実装](https://www.notion.so/melty-inc/1a77bdbab28380aabf21d65df4ecc958?pvs=4)

## やったこと
- [Unleashリポジトリ](https://github.com/magaport/Unleash)にあった渡邉雄太用のメールテンプレートを本リポジトリ配下に移管
- 同様にメールの件名も本リポジトリ配下に移管
- 手順をREADMEに追加

## 確認してほしいこと
- 検証環境にzipをアップロードし、カスタマイズしているメールをテストする