### PR TITLE
chore: ピックアップタグセクションは pickup というタグを固定で表示するようにする

### DIFF
--- a/home.hbs
+++ b/home.hbs
@@ -35,6 +35,6 @@
         {{> "components/featured-articles" posts=posts}}
     {{/get}}
 
-    {{> "components/pickup-tag" tag="osaka"}}
+    {{> "components/pickup-tag"}}
     {{> "components/partners"}}
 </div>

--- a/partials/components/pickup-tag.hbs
+++ b/partials/components/pickup-tag.hbs
@@ -1,13 +1,4 @@
-{{!--
-Pickup Tag Component
-Usage: {{> "components/pickup-tag" tag="osaka"}}
-
-Parameters:
-- tag: Tag slug to display (required)
---}}
-
-{{#if tag}}
-{{#get "tags" filter="slug:{{tag}}" limit="1"}}
+{{#get "tags" filter="slug:pickup" limit="1"}}
 {{#foreach tags}}
 <section class="pickup-tag">
     <div class="pickup-tag-container">
@@ -40,4 +31,3 @@ Parameters:
 </section>
 {{/foreach}}
 {{/get}}
-{{/if}}


### PR DESCRIPTION
Ghost の仕様ではタグに対してピックアップというような識別子を持たせることはできない。
ピックアップされたタグを管理者側で変更できる仕組みとして、 pickup という slug を固定で表示するようにし、管理画面側で pickup という slug を付けるタグを変更することで実現する