### PR TITLE
feat: source-fms-hero の EC 連携 (FMS loader + mp-fms-cart) を統合

### DIFF
--- a/callback-pages.hbs
+++ b/callback-pages.hbs
@@ -1,0 +1,24 @@
+<html>
+  <head>
+    <title>Processing...</title>
+    <script type="module">
+        import "{{@custom.fms_js_base_url}}/loader/index.js";
+        FMS.load(["unleash"], {
+            baseUrl: "{{@custom.fms_js_base_url}}",
+            tkmDomain: "{{@custom.fms_tkm_base_url}}",
+            servicePath: "{{@custom.fms_base_api_service_path}}",
+            apiBaseUrl: "{{@custom.fms_base_api_url}}",
+            mylibrary: {
+                search_endpoint: "https://www.fujisan.co.jp/library/showcase",
+                list_endpoint: ''
+            }
+        }, async (unleash) => {
+            await unleash.init();
+            unleash._processCallback();
+        });
+    </script>
+  </head>
+  <body>
+    <p class="login_process"></p>
+  </body>
+</html>

--- a/default.hbs
+++ b/default.hbs
@@ -21,6 +21,41 @@
         }
     </style>
 
+    {{!-- FMS / MagaCommerce loader --}}
+    {{#if @custom.fms_js_base_url}}
+    <script type="module">
+        import "{{@custom.fms_js_base_url}}/loader/index.js";
+
+        FMS.load(["base/user", "membershipCard", "mylibrary", "pdfviewer", "unleash", "cart"], {
+            baseUrl: "{{@custom.fms_js_base_url}}",
+            tkmDomain: "{{@custom.fms_tkm_base_url}}",
+            servicePath: "{{@custom.fms_base_api_service_path}}",
+            apiBaseUrl: "{{@custom.fms_base_api_url}}",
+            mylibrary: {
+                search_endpoint: "https://www.fujisan.co.jp/library/showcase",
+                list_endpoint: ''
+            },
+            cart: {
+                "k": "{{@custom.fms_cart_key}}",
+                "h": "{{@custom.fms_cart_api_base_url}}"
+            }
+        }, async (base, card, myl, pdf, unleash, cart) => {
+            base.init();
+            myl.init();
+            unleash.init();
+            await cart.init();
+
+            await customElements.whenDefined('fms-cart');
+            const cartEl = document.getElementById('fms-cart');
+            await new Promise(resolve => {
+                const check = () => typeof cartEl?.restoreState === 'function' ? resolve() : requestAnimationFrame(check);
+                check();
+            });
+            cartEl.restoreState();
+        });
+    </script>
+    {{/if}}
+
     <script>
         /* The script for calculating the color contrast has been taken from
         https://gomakethings.com/dynamically-changing-the-text-color-based-on-background-color-contrast-with-vanilla-js/ */
@@ -77,6 +112,10 @@
 
 {{!-- Ghost outputs required functional scripts with this tag, it should always be the last thing before the closing body tag --}}
 {{ghost_foot}}
+
+{{!-- FMS Web Components (cart / order history) --}}
+<fms-cart id="fms-cart" restrict-multiple-products="false"></fms-cart>
+<order-history></order-history>
 
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -177,6 +177,36 @@
 				"type": "boolean",
 				"default": true,
 				"group": "post"
+			},
+			"fms_js_base_url": {
+				"type": "text",
+				"default": "",
+				"description": "[FMS] jsBaseUrl"
+			},
+			"fms_tkm_base_url": {
+				"type": "text",
+				"default": "",
+				"description": "[FMS] tkmBaseUrl"
+			},
+			"fms_base_api_url": {
+				"type": "text",
+				"default": "",
+				"description": "[FMS] baseApi URL"
+			},
+			"fms_base_api_service_path": {
+				"type": "text",
+				"default": "",
+				"description": "[FMS] baseApi servicePath"
+			},
+			"fms_cart_key": {
+				"type": "text",
+				"default": "",
+				"description": "[FMS] cart key (cartモジュール初期化用)"
+			},
+			"fms_cart_api_base_url": {
+				"type": "text",
+				"default": "",
+				"description": "[FMS] cart API base URL (例: https://api-unleash-dev.magacommerce.jp)"
 			}
 		}
 	},

--- a/partials/articles-cta.hbs
+++ b/partials/articles-cta.hbs
@@ -7,6 +7,9 @@
 			<a class="gh-post-upgrade-signup-link" href="#/portal/signup" data-portal="signup">
 				{{t "🏀入部する⛹️"}}
 			</a>
+			{{^if @member}}
+				<p class="fms-login-button"><small>{{t "すでに会員ですか?"}} <a href="#" onclick="return window.FMS?.unleash?.login();">{{t "ログイン"}}</a></small></p>
+			{{/if}}
 		</div>
 	</aside>
 {{/if}}

--- a/partials/components/navigation.hbs
+++ b/partials/components/navigation.hbs
@@ -42,11 +42,11 @@
 
                 {{#if @member}}
                     <div class="gh-navigation-siginin-button">
-                        <a href="#/portal/account" data-portal="subscribe">{{t "アカウント"}}</a>
+                        <a href="javascript:" onclick="window.FMS?.unleash?.logout()">{{t "ログアウト"}}</a>
                     </div>
                 {{else}}
                     <div class="gh-navigation-siginin-button">
-                        <a href="#/portal/signin" data-portal="signin">{{t "ログイン"}}</a>
+                        <a href="javascript:" data-login-button onclick="window.FMS?.unleash?.login()">{{t "ログイン"}}</a>
                     </div>
                 {{/if}}
             </div>
@@ -58,7 +58,7 @@
                 {{#if @member}}
                     <div class="gh-navigation-signout-button">
                         <div>-</div>
-                        <a href="javascript:" data-members-signout>Log Out</a>
+                        <a href="javascript:" onclick="window.FMS?.unleash?.logout()">{{t "ログアウト"}}</a>
                     </div>
                 {{/if}}
             </div>

--- a/routes.yaml
+++ b/routes.yaml
@@ -1,0 +1,13 @@
+routes:
+  /callback/:
+    template: callback-pages
+
+
+collections:
+  /:
+    permalink: /{slug}/
+    template: index
+
+taxonomies:
+  tag: /tag/{slug}/
+  author: /author/{slug}/


### PR DESCRIPTION
## pull requestの目的

source-fms-hero テーマで実装されている FMS / MagaCommerce の EC 連携機能を、ghost-support テーマに結合する。
これにより ghost-support でも FMS OIDC ログイン・fms-cart・order-history が動作するようになる。

ref https://github.com/magaport/Unleash/issues/598

## やったこと

source-fms-hero の実装を参照に、ghost-support 側へ以下 5 コミットで段階的に結合：

1. **FMS/MagaCommerce 連携用カスタムフィールドを追加** (\`package.json\`)
   - \`fms_js_base_url\` / \`fms_tkm_base_url\` / \`fms_base_api_url\` / \`fms_base_api_service_path\`
   - \`fms_cart_key\` / \`fms_cart_api_base_url\` (source-fms-hero ではハードコードだったが custom field 化して環境別に設定可能に)

2. **\`default.hbs\` に FMS loader と Web Components を統合**
   - head に FMS loader スクリプト（\`fms_js_base_url\` 未設定時は起動しないガード付き）
   - \`FMS.load([\"base/user\", \"membershipCard\", \"mylibrary\", \"pdfviewer\", \"unleash\", \"cart\"], ...)\` で 6 モジュール一括初期化
   - body 末尾に \`<fms-cart>\` / \`<order-history>\` Web Components を配置

3. **FMS OIDC コールバック対応** (\`routes.yaml\`, \`callback-pages.hbs\`)
   - \`/callback/\` ルートを callback-pages テンプレートへマッピング
   - \`unleash._processCallback()\` でコールバック処理を完了

4. **ナビゲーションのログイン/ログアウトを FMS.unleash に切り替え** (\`partials/components/navigation.hbs\`)
   - Ghost Portal (\`#/portal/signin\`, \`data-members-signout\`) → \`window.FMS.unleash.login()\` / \`logout()\`
   - 既存の \`gh-navigation-pagetitle\` / \`gh-navigation-user\` レイアウトは維持

5. **有料記事 CTA に既存会員向けログイン導線を追加** (\`partials/articles-cta.hbs\`)
   - 未ログインユーザーが有料記事に遭遇した際、「すでに会員ですか? ログイン」リンクを表示
   - 重複登録防止が目的

## 特に確認してほしいところ

- **カスタムフィールドの値**: 動作確認には Ghost 管理画面で以下 6 フィールドへ値を設定する必要があります（本 PR 内では空デフォルト）。実値は別途 Ghost 管理画面側で入力済み。
  - \`fms_js_base_url\` / \`fms_tkm_base_url\` / \`fms_base_api_url\` / \`fms_base_api_service_path\`
  - \`fms_cart_key\` / \`fms_cart_api_base_url\`
- **FMS ログインフロー**: ナビゲーション「ログイン」押下 → FMS OIDC 認証 → \`/callback/\` に戻って \`_processCallback()\` → サイト復帰、という一連のフローが通るか
- **cart Web Component**: 商品追加 → \`<fms-cart>\` 表示 → \`restoreState()\` で状態復元が動作するか
- **navigation 変更の影響**: ログイン済み状態で「ログアウト」リンクが意図通り働くか（従来の \`data-members-signout\` / \`#/portal/account\` と入れ替えている）

## 気になったところ

- source-fms-hero 由来の独自機能（\`#hero\` カルーセル・\`tag:-x-hidden\` フィルタ・\`typography/fonts\` など）は EC 連携と無関係なので移植対象外とした
- 過去ブランチ \`feat/ec-integration\` は独自 \`magacommerce.js\` ベースの別実装だったため破棄し、source-fms-hero 準拠で作り直した（参考として \`feat/ec-integration\` は残している）
- cart の \`k\` / \`h\` は source-fms-hero では dev 環境値がハードコードされていたが、本 PR では custom field 化している

🤖 Generated with [Claude Code](https://claude.com/claude-code)