### PR TITLE
🎨 Cove IDをGhost管理画面から設定可能に変更

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -72,8 +72,9 @@
     });
 </script>
 
-{{!-- 以下のコードを利用したいCoveのアカウントによって変更する --}}
-<script src="https://cdn.cove.chat/comments.js" data-cove-id="76bd734bb43a9136366c78a85fd1829f" async></script>
+{{#if @custom.cove_id}}
+<script src="https://cdn.cove.chat/comments.js" data-cove-id="{{@custom.cove_id}}" async></script>
+{{/if}}
 
 {{!-- Ghost outputs required functional scripts with this tag, it should always be the last thing before the closing body tag --}}
 {{ghost_foot}}

--- a/package.json
+++ b/package.json
@@ -177,6 +177,11 @@
 				"type": "boolean",
 				"default": true,
 				"group": "post"
+			},
+			"cove_id": {
+				"type": "text",
+				"default": "",
+				"description": "CoveコメントウィジェットのID（Cove管理画面で確認できるdata-cove-id）。空の場合はCoveスクリプトが読み込まれません。"
 			}
 		}
 	},


### PR DESCRIPTION
## pull requestの目的

ベタ書きされていたCove IDを、Ghost管理画面のデザイン設定から変更できるようにする。

## やったこと

- `package.json` の `config.custom` に `cove_id`（text型）フィールドを追加
- `default.hbs` のベタ書きID `76bd734bb43a9136366c78a85fd1829f` を `{{@custom.cove_id}}` に置換
- `{{#if @custom.cove_id}}` で囲み、IDが未設定の場合はCoveスクリプトを読み込まないように変更

**設定方法:** Ghost管理画面 → Design → Customize → 「Cove ID」フィールドに `data-cove-id` の値を入力

## 特に確認してほしいところ

- Ghost管理画面のDesign設定に「Cove ID」フィールドが表示されること
- IDを設定するとCoveのコメントウィジェットが正常に動作すること
- IDを空にするとスクリプトが読み込まれないこと

## 気になったところ

特になし