### PR TITLE
fix(ec): ec-init が本番で FMS の js を 404 する問題を修正

### DIFF
--- a/partials/components/ec-init.hbs
+++ b/partials/components/ec-init.hbs
@@ -1,22 +1,33 @@
 {{!-- mp-fms-js (ローダー) + mp-fms-cart (Web Components) --}}
+{{!-- サービス URL は assets/js/ec-config.js の window.EC_CONFIG から供給する（package.json custom の上限回避）。
+      ec-config.js は各環境で ec-config.example.js からコピーして設定する（.gitignore 対象）。
+      URL が localhost の場合は Vite dev（/src/*）、それ以外は本番の静的ビルド（/loader/index.js・/js/main.js）で動作する。 --}}
 <script src="{{asset "js/ec-config.js"}}"></script>
 <script type="module">
   const config = window.EC_CONFIG || {};
-  const MP_FMS_JS_URL = config.MP_FMS_JS_URL || '';
-  const MP_FMS_CART_URL = config.MP_FMS_CART_URL || '';
-  const MP_BASE_API_URL = config.MP_BASE_API_URL || '';
-  const MP_TKM_URL = config.MP_TKM_URL || '';
-  const MP_MEDUSA_URL = config.MP_MEDUSA_URL || '';
+  const MP_FMS_JS_URL = config.MP_FMS_JS_URL || 'http://localhost:18081';
+  const MP_FMS_CART_URL = config.MP_FMS_CART_URL || 'http://localhost:18083';
+  const MP_BASE_API_URL = config.MP_BASE_API_URL || 'http://localhost:18082';
+  const MP_TKM_URL = config.MP_TKM_URL || 'http://localhost:18080';
+  const MP_MEDUSA_URL = config.MP_MEDUSA_URL || 'http://localhost:9000';
 
-  await import(`${MP_FMS_JS_URL}/src/loader/index.js`);
-  await import(`${MP_FMS_CART_URL}/src/main.ts`);
+  const isDev = /localhost|127\.0\.0\.1/.test(MP_FMS_JS_URL);
 
-  window.FMS.setManifest({
-    'oidc': { file: 'src/tkm/oidc.js', deps: [] },
-    'base/user': { file: 'src/base/user/user-api.js', deps: ['oidc'] },
-    'unleash': { file: 'src/unleash/unleash.js', deps: ['oidc', 'base/user'] },
-    'cart': { file: `${MP_FMS_CART_URL}/src/main.ts`, deps: ['oidc', 'base/user'] }
-  });
+  if (isDev) {
+    // ローカル開発（Vite dev）: ソースを直接 import
+    await import(`${MP_FMS_JS_URL}/src/loader/index.js`);
+    await import(`${MP_FMS_CART_URL}/src/main.ts`);
+    window.FMS.setManifest({
+      'oidc': { file: 'src/tkm/oidc.js', deps: [] },
+      'base/user': { file: 'src/base/user/user-api.js', deps: ['oidc'] },
+      'unleash': { file: 'src/unleash/unleash.js', deps: ['oidc', 'base/user'] },
+      'cart': { file: `${MP_FMS_CART_URL}/src/main.ts`, deps: ['oidc', 'base/user'] }
+    });
+  } else {
+    // 本番の静的ビルド: ローダーは /loader/index.js（/loader/manifest.json で解決）、カートは /js/main.js
+    await import(`${MP_FMS_JS_URL}/loader/index.js`);
+    await import(`${MP_FMS_CART_URL}/js/main.js`);
+  }
 
   FMS.load(['oidc', 'base/user', 'unleash'], {
     baseUrl: MP_FMS_JS_URL,


### PR DESCRIPTION
## 概要
PR #160 で導入した `ec-config.js`(`window.EC_CONFIG`)方式の `ec-init.hbs` が、本番環境で **FMS の js 読み込みが 404** になる問題を修正します。

## 原因
`ec-init.hbs` が FMS スクリプトを常に **Vite dev のソースパス**から import していました。
- `${MP_FMS_JS_URL}/src/loader/index.js`
- `${MP_FMS_CART_URL}/src/main.ts`（`.ts`）
- `src/tkm/oidc.js`

本番の静的ビルド配信では以下のパスのため、`/src/*` は存在せず 404 になります。
- mp-fms-js: `/loader/index.js`（`/loader/manifest.json` で解決）
- mp-fms-cart: `/js/main.js`

## 修正
`MP_FMS_JS_URL` が `localhost` かどうかで dev / 本番を自動判定し、本番では本番パスを import するようにしました（稼働中の `@custom` 版 `ec-init` の本番分岐に揃えています）。

- 本番: `${MP_FMS_JS_URL}/loader/index.js` + `${MP_FMS_CART_URL}/js/main.js`
- dev : 従来どおり `/src/*`（`setManifest` あり）
- `servicePath` / `api_key` は引き続き `@custom` から供給（URL 5件を `EC_CONFIG` に外出しした分、`package.json` の custom 上限に余裕ができる）

## 動作確認（melty.unleashcms.dev）
- `/assets/js/ec-config.js` → 200
- `/fms-js/loader/index.js` → 200
- `/cart/js/main.js` → 200
- 商品一覧が正常表示（「りんご ￥500」）、`FMS.isReady()=true`

## デプロイ時の注意（別途手順）
`ec-config.js` は `.gitignore` 対象で本体はコミットされません。**各環境で `assets/js/ec-config.example.js` を `assets/js/ec-config.js` にコピーして URL を設定**してください（未設置だと `/assets/js/ec-config.js` が 404 になり `window.EC_CONFIG` が未定義になります）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwHRUyVQPH45dFTTc9VZLy