### PR TITLE
chore: EC問い合わせページを追加

### DIFF
--- a/ec-contact.hbs
+++ b/ec-contact.hbs
@@ -1,0 +1,5 @@
+{{!< default }}
+
+<main class="gh-main">
+  <ec-contact support-email="{{@site.support_email_address}}"></ec-contact>
+</main>

--- a/order-complete.hbs
+++ b/order-complete.hbs
@@ -1,7 +1,7 @@
 {{!< default }}
 
 <main class="gh-main">
-  <fms-cart inline="true" hide-button="true" start-view="complete" continue-shopping-url="/product/list"></fms-cart>
+  <fms-cart inline="true" hide-button="true" start-view="complete" continue-shopping-url="/product/list" contact-url="/ec-contact/"></fms-cart>
   <script>
     document.addEventListener("fms:event", function(e) {
       var type = e.detail && e.detail.eventType;


### PR DESCRIPTION
## この PR の目的

EC 連携における問い合わせ用ページ (`ec-contact`) を追加する。サポートメールアドレスは Ghost 管理画面の Portal 設定 (`Settings → Membership → Portal → サポートメールアドレス`) の値 (`@site.support_email_address`) をそのまま参照する。

あわせて、注文完了ページ (`order-complete.hbs`) の `fms-cart` に `contact-url="/ec-contact/"` を指定し、問い合わせページへの導線を追加した。

## 関連 Issue

なし

## レビュー観点

- `ec-contact.hbs` の `support-email` が Portal 設定のサポートメールアドレスと一致すること
- 注文完了ページから問い合わせページへの導線 (`contact-url`) が正しく機能すること